### PR TITLE
#22: ValidatingServiceLocator

### DIFF
--- a/src/main/java/com/artipie/maven/aether/ServiceLocatorException.java
+++ b/src/main/java/com/artipie/maven/aether/ServiceLocatorException.java
@@ -1,0 +1,50 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.artipie.maven.aether;
+
+/**
+ * Represents {@link org.eclipse.aether.spi.locator.ServiceLocator} misconfiguration.
+ * The given service cannot be located or initialized.
+ * @since 0.1
+ */
+public class ServiceLocatorException extends IllegalStateException {
+
+    /**
+     * Hardcodes the message.
+     * @param service Service type
+     */
+    public ServiceLocatorException(final Class<?> service) {
+        this(service, null);
+    }
+
+    /**
+     * Hardcodes the message.
+     * @param service Service type
+     * @param cause The exception cause
+     */
+    public ServiceLocatorException(final Class<?> service, final Throwable cause) {
+        super(String.format("Cannot locate or initialize service %s", service), cause);
+    }
+}

--- a/src/main/java/com/artipie/maven/aether/ServiceLocatorException.java
+++ b/src/main/java/com/artipie/maven/aether/ServiceLocatorException.java
@@ -32,7 +32,8 @@ package com.artipie.maven.aether;
 public class ServiceLocatorException extends IllegalStateException {
 
     /**
-     * Hardcodes the message.
+     * Constructs a new exception instance with no cause.
+     * Internally it builds its detail message incorporating given service type.
      * @param service Service type
      */
     public ServiceLocatorException(final Class<?> service) {
@@ -40,7 +41,8 @@ public class ServiceLocatorException extends IllegalStateException {
     }
 
     /**
-     * Hardcodes the message.
+     * Constructs a new exception instance.
+     * Internally it builds its detail message incorporating given service type.
      * @param service Service type
      * @param cause The exception cause
      */

--- a/src/main/java/com/artipie/maven/aether/ServiceLocatorFactory.java
+++ b/src/main/java/com/artipie/maven/aether/ServiceLocatorFactory.java
@@ -44,16 +44,15 @@ public final class ServiceLocatorFactory {
      * @todo #10:30min Inject a LocalRepository into a ServiceLocator.
      *  Current design made ServiceLocatorFactory and LocalRepository coupled together.
      *  We can retrieve a LocalRepository directly from the ServiceLocator
-     * @todo #10:30min Create a ServiceLocator impl class that validates retrievable services.
-     *  {@link ServiceLocator#getService} returns null if the service was not found.
-     *  In most cases you actually need to throw an exception.
      * @checkstyle NonStaticMethodCheck (2 lines) Introduce class fields in following pull requests
      */
-    public ServiceLocator serviceLocator() {
-        return MavenRepositorySystemUtils.newServiceLocator()
-            .setService(
-                RepositoryConnectorFactory.class,
-                BasicRepositoryConnectorFactory.class
-            );
+    public ValidatingServiceLocator serviceLocator() {
+        return new ValidatingServiceLocator(
+            MavenRepositorySystemUtils.newServiceLocator()
+                .setService(
+                    RepositoryConnectorFactory.class,
+                    BasicRepositoryConnectorFactory.class
+                )
+        );
     }
 }

--- a/src/main/java/com/artipie/maven/aether/ValidatingServiceLocator.java
+++ b/src/main/java/com/artipie/maven/aether/ValidatingServiceLocator.java
@@ -1,0 +1,82 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.artipie.maven.aether;
+
+import java.util.List;
+import java.util.Optional;
+import org.eclipse.aether.spi.locator.ServiceLocator;
+
+/**
+ * A decorator over {@link ServiceLocator}.
+ * Overrides {@link ServiceLocator#getService(Class)} contract to return null
+ * if the service cannot be located or initialized.
+ * It throws {@link ServiceLocatorException} instead.
+ * Provides a new method wrapping nullable value with {@link Optional}.
+ * @since 0.1
+ */
+public final class ValidatingServiceLocator implements ServiceLocator {
+
+    /**
+     * Actual ServiceLocator.
+     */
+    private final ServiceLocator locator;
+
+    /**
+     * All args constructor.
+     * @param locator ServiceLocator instance
+     */
+    public ValidatingServiceLocator(final ServiceLocator locator) {
+        this.locator = locator;
+    }
+
+    /**
+     * Returns the original ServiceLocator instance.
+     * @return ServiceLocator instance
+     */
+    public ServiceLocator unwrap() {
+        return this.locator;
+    }
+
+    /**
+     * Wraps the original nullable return value with {@link Optional}.
+     * @param type Service class
+     * @param <T> Service
+     * @return Present if the service can be located and initialized
+     */
+    public <T> Optional<T> getServiceOpt(final Class<T> type) {
+        return Optional.ofNullable(this.locator.getService(type));
+    }
+
+    @Override
+    public <T> T getService(final Class<T> type) {
+        return this.getServiceOpt(type)
+            .orElseThrow(() -> new ServiceLocatorException(type));
+    }
+
+    @Override
+    public <T> List<T> getServices(final Class<T> type) {
+        return this.locator.getServices(type);
+    }
+}

--- a/src/test/java/com/artipie/maven/aether/ValidatingServiceLocatorTest.java
+++ b/src/test/java/com/artipie/maven/aether/ValidatingServiceLocatorTest.java
@@ -1,0 +1,96 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.artipie.maven.aether;
+
+import com.artipie.maven.test.OptionalAssertions;
+import java.util.List;
+import org.eclipse.aether.spi.locator.ServiceLocator;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link ValidatingServiceLocator}.
+ * @since 0.1
+ */
+public final class ValidatingServiceLocatorTest {
+
+    /**
+     * Always returns null.
+     */
+    private static final ServiceLocator NULL = new ServiceLocator() {
+        @Override
+        public <T> T getService(final Class<T> type) {
+            return null;
+        }
+
+        @Override
+        public <T> List<T> getServices(final Class<T> type) {
+            return null;
+        }
+    };
+
+    /**
+     * Instantiates a service by its default constructor.
+     */
+    private static final ServiceLocator NEW_INSTANCE = new ServiceLocator() {
+        @Override
+        public <T> T getService(final Class<T> type) {
+            try {
+                return type.getDeclaredConstructor().newInstance();
+            } catch (final ReflectiveOperationException | SecurityException ex) {
+                throw new ServiceLocatorException(type, ex);
+            }
+        }
+
+        @Override
+        public <T> List<T> getServices(final Class<T> type) {
+            return null;
+        }
+    };
+
+    @Test
+    public void shouldReturnEmptyOnNull() {
+        OptionalAssertions.empty(
+            new ValidatingServiceLocator(ValidatingServiceLocatorTest.NULL)
+                .getServiceOpt(ValidatingServiceLocatorTest.class)
+        );
+    }
+
+    @Test
+    public void shouldReturnPresent() {
+        OptionalAssertions.present(
+            new ValidatingServiceLocator(ValidatingServiceLocatorTest.NEW_INSTANCE)
+                .getServiceOpt(ValidatingServiceLocatorTest.class)
+        );
+    }
+
+    @Test
+    public void shouldThrowOnNull() {
+        Assertions.assertThrows(
+            ServiceLocatorException.class,
+            () -> new ValidatingServiceLocator(ValidatingServiceLocatorTest.NULL)
+                .getService(ValidatingServiceLocatorTest.class));
+    }
+}


### PR DESCRIPTION
From #22:
`org.eclipse.aether.spi.locator.ServiceLocator` is a ServiceLocator pattern interface. It creates/retrieves services by matching service class. If the service was not yet registered it simply returns null forcing you to make a null check on each invocation.
We should hide null checks in another class implementing the interface.