### PR TITLE
#24: implement FileCoordinates coords() and path()

### DIFF
--- a/src/main/java/com/artipie/maven/FileCoordinates.java
+++ b/src/main/java/com/artipie/maven/FileCoordinates.java
@@ -77,22 +77,33 @@ public final class FileCoordinates implements ArtifactCoordinates {
      * Builds colon-delimited Gradle-style line.
      * groupId:artifactId:extension[:classifier]:version.
      * @return Artifact coordinates
-     * @todo #10:30min Implement FileCoordinates coords() method and test it.
-     *  The method was not implemented to split the original pull request.
      */
     public String coords() {
-        throw new UnsupportedOperationException("coords() WIP");
+        final var builder = new StringBuilder(
+            String.join(":", this.groupId(), this.artifactId(), this.extension())
+        );
+        if (!this.classifier().isBlank()) {
+            builder.append(':').append(this.classifier());
+        }
+        if (!this.version().isBlank()) {
+            builder.append(':').append(this.version());
+        }
+        return builder.toString();
     }
 
     /**
      * Rebuilds back the original path string.
      * groupId/artifactId/version/name
      * @return Original path string
-     * @todo #10:30min Implement FileCoordinates coords() method and test it.
-     *  The method was not implemented to split the original pull request.
      */
     public String path() {
-        throw new UnsupportedOperationException("path() WIP");
+        return String.join(
+            "/",
+            this.groupId().replace('.', '/'),
+            this.artifactId(),
+            this.version(),
+            this.name()
+        );
     }
 
     /**

--- a/src/test/java/com/artipie/maven/FileCoordinatesTest.java
+++ b/src/test/java/com/artipie/maven/FileCoordinatesTest.java
@@ -25,6 +25,8 @@
 package com.artipie.maven;
 
 import com.artipie.maven.test.OptionalAssertions;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -96,7 +98,10 @@ public final class FileCoordinatesTest {
         "'group:example:pom:1.0','group/example/1.0/example-1.0.pom'"
     })
     public void testCoords(final String coords, final String path) throws Exception {
-        Assertions.assertEquals(coords, new FileCoordinates(path).coords());
+        MatcherAssert.assertThat(
+            new FileCoordinates(path).coords(),
+            CoreMatchers.is(coords)
+        );
     }
 
     @ParameterizedTest
@@ -105,6 +110,9 @@ public final class FileCoordinatesTest {
         "group/example/2.0/example-2.0.pom"
     })
     public void testPath(final String path) throws Exception {
-        Assertions.assertEquals(path, new FileCoordinates(path).path());
+        MatcherAssert.assertThat(
+            new FileCoordinates(path).path(),
+            CoreMatchers.is(path)
+        );
     }
 }

--- a/src/test/java/com/artipie/maven/FileCoordinatesTest.java
+++ b/src/test/java/com/artipie/maven/FileCoordinatesTest.java
@@ -97,8 +97,9 @@ public final class FileCoordinatesTest {
         "'org.group:example:jar:classifier:1.0','org/group/example/1.0/example-1.0-classifier.jar'",
         "'group:example:pom:1.0','group/example/1.0/example-1.0.pom'"
     })
-    public void testCoords(final String coords, final String path) throws Exception {
+    public void shouldReturnCoords(final String coords, final String path) throws Exception {
         MatcherAssert.assertThat(
+            "FileCoordinates#coords() should return a valid coords string",
             new FileCoordinates(path).coords(),
             new IsEqual<>(coords)
         );
@@ -109,8 +110,9 @@ public final class FileCoordinatesTest {
         "org/group/example/2.0/example-2.0-classifier.jar",
         "group/example/2.0/example-2.0.pom"
     })
-    public void testPath(final String path) throws Exception {
+    public void shouldReturnPath(final String path) throws Exception {
         MatcherAssert.assertThat(
+            "FileCoordinates#path() should return an original path string",
             new FileCoordinates(path).path(),
             new IsEqual<>(path)
         );

--- a/src/test/java/com/artipie/maven/FileCoordinatesTest.java
+++ b/src/test/java/com/artipie/maven/FileCoordinatesTest.java
@@ -28,6 +28,7 @@ import com.artipie.maven.test.OptionalAssertions;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 /**
@@ -84,8 +85,26 @@ public final class FileCoordinatesTest {
     public void testClassifierEmpty() throws Exception {
         OptionalAssertions.empty(
             new FileCoordinates(
-            "group/example/1.0/example-1.0.jar"
+                "group/example/1.0/example-1.0.jar"
             ).tryClassifier()
         );
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "'org.group:example:jar:classifier:1.0','org/group/example/1.0/example-1.0-classifier.jar'",
+        "'group:example:pom:1.0','group/example/1.0/example-1.0.pom'"
+    })
+    public void testCoords(final String coords, final String path) throws Exception {
+        Assertions.assertEquals(coords, new FileCoordinates(path).coords());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "org/group/example/2.0/example-2.0-classifier.jar",
+        "group/example/2.0/example-2.0.pom"
+    })
+    public void testPath(final String path) throws Exception {
+        Assertions.assertEquals(path, new FileCoordinates(path).path());
     }
 }

--- a/src/test/java/com/artipie/maven/FileCoordinatesTest.java
+++ b/src/test/java/com/artipie/maven/FileCoordinatesTest.java
@@ -25,8 +25,8 @@
 package com.artipie.maven;
 
 import com.artipie.maven.test.OptionalAssertions;
-import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -100,7 +100,7 @@ public final class FileCoordinatesTest {
     public void testCoords(final String coords, final String path) throws Exception {
         MatcherAssert.assertThat(
             new FileCoordinates(path).coords(),
-            CoreMatchers.is(coords)
+            new IsEqual<>(coords)
         );
     }
 
@@ -112,7 +112,7 @@ public final class FileCoordinatesTest {
     public void testPath(final String path) throws Exception {
         MatcherAssert.assertThat(
             new FileCoordinates(path).path(),
-            CoreMatchers.is(path)
+            new IsEqual<>(path)
         );
     }
 }


### PR DESCRIPTION
From #24 :
`FileCoordinates` contains two methods: `coords()` and `path()` that throw `UnsupportedOperationException`. We should implement it (and unit test too).
The class was not implemented to split the original pull request.