### PR TITLE
#28: Asto integration

### DIFF
--- a/src/main/java/com/artipie/maven/aether/AstoTransporter.java
+++ b/src/main/java/com/artipie/maven/aether/AstoTransporter.java
@@ -64,8 +64,15 @@ public final class AstoTransporter extends AbstractTransporter {
 
     @Override
     public void implPeek(final PeekTask task) throws Exception {
-        if (!this.asto.exists(new TaskKey(task).key())) {
-            throw new ResourceNotFoundException(task.getLocation().toString());
+        final Key key = new TaskKey(task).key();
+        if (!this.asto.exists(key)) {
+            throw new ResourceNotFoundException(
+                String.format(
+                    "Resource does not exist in Asto: key %s and location %s",
+                    key,
+                    task.getLocation()
+                )
+            );
         }
     }
 

--- a/src/main/java/com/artipie/maven/aether/AstoTransporter.java
+++ b/src/main/java/com/artipie/maven/aether/AstoTransporter.java
@@ -1,0 +1,118 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.artipie.maven.aether;
+
+import com.artipie.asto.Key;
+import com.artipie.asto.blocking.BlockingStorage;
+import org.apache.commons.io.IOUtils;
+import org.eclipse.aether.spi.connector.transport.AbstractTransporter;
+import org.eclipse.aether.spi.connector.transport.GetTask;
+import org.eclipse.aether.spi.connector.transport.PeekTask;
+import org.eclipse.aether.spi.connector.transport.PutTask;
+import org.eclipse.aether.spi.connector.transport.TransportTask;
+import org.eclipse.aether.spi.connector.transport.Transporter;
+
+/**
+ * Adapts Asto to {@link Transporter}.
+ * @since 0.1
+ */
+public final class AstoTransporter extends AbstractTransporter {
+
+    /**
+     * Asto.
+     */
+    private final BlockingStorage asto;
+
+    /**
+     * All args constructor.
+     * @param asto Asto
+     */
+    public AstoTransporter(final BlockingStorage asto) {
+        this.asto = asto;
+    }
+
+    @Override
+    public int classify(final Throwable error) {
+        int code = Transporter.ERROR_OTHER;
+        if (error instanceof ResourceNotFoundException) {
+            code = Transporter.ERROR_NOT_FOUND;
+        }
+        return code;
+    }
+
+    @Override
+    public void implPeek(final PeekTask task) throws Exception {
+        if (!this.asto.exists(new TaskKey(task).key())) {
+            throw new ResourceNotFoundException(task.getLocation().toString());
+        }
+    }
+
+    @Override
+    public void implGet(final GetTask task) throws Exception {
+        try (var write = task.newOutputStream()) {
+            IOUtils.write(this.asto.value(new TaskKey(task).key()), write);
+        }
+    }
+
+    @Override
+    public void implPut(final PutTask task) throws Exception {
+        try (var read = task.newInputStream()) {
+            this.asto.save(new TaskKey(task).key(), IOUtils.toByteArray(read));
+        }
+    }
+
+    @Override
+    public void implClose() {
+        // noop
+    }
+
+    /**
+     * Maps TransportTask location to Asto key.
+     * @since 0.1
+     */
+    private final class TaskKey {
+
+        /**
+         * Transport task.
+         */
+        private final TransportTask task;
+
+        /**
+         * All args constructor.
+         * @param task Transport task
+         */
+        private TaskKey(final TransportTask task) {
+            this.task = task;
+        }
+
+        /**
+         * Maps TransportTask location to Asto key.
+         * @return Task location as Asto key.
+         */
+        private Key key() {
+            return new Key.From(this.task.getLocation().getPath());
+        }
+    }
+}

--- a/src/main/java/com/artipie/maven/aether/AstoTransporterFactory.java
+++ b/src/main/java/com/artipie/maven/aether/AstoTransporterFactory.java
@@ -1,0 +1,65 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.artipie.maven.aether;
+
+import com.artipie.asto.blocking.BlockingStorage;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.spi.connector.transport.Transporter;
+import org.eclipse.aether.spi.connector.transport.TransporterFactory;
+import org.eclipse.aether.transfer.NoTransporterException;
+
+/**
+ * Adapts Asto to {@link TransporterFactory}.
+ * @since 0.1
+ */
+public final class AstoTransporterFactory implements TransporterFactory {
+
+    /**
+     * Asto.
+     */
+    private final BlockingStorage asto;
+
+    /**
+     * All args constructor.
+     * @param asto Asto.
+     */
+    public AstoTransporterFactory(final BlockingStorage asto) {
+        this.asto = asto;
+    }
+
+    @Override
+    public Transporter newInstance(
+        final RepositorySystemSession session,
+        final RemoteRepository repository
+    ) throws NoTransporterException {
+        return new AstoTransporter(this.asto);
+    }
+
+    @Override
+    public float getPriority() {
+        return 0;
+    }
+}

--- a/src/main/java/com/artipie/maven/aether/ResourceNotFoundException.java
+++ b/src/main/java/com/artipie/maven/aether/ResourceNotFoundException.java
@@ -1,0 +1,50 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.artipie.maven.aether;
+
+/**
+ * A marker exception indicating that given resource does not exist.
+ * Maven relies on exceptions to handle this logic.
+ * @since 0.1
+ */
+public class ResourceNotFoundException extends RuntimeException {
+
+    /**
+     * Super constructor.
+     * @param message Detail message
+     */
+    public ResourceNotFoundException(final String message) {
+        super(message);
+    }
+
+    /**
+     * Super constructor.
+     * @param message Detail message
+     * @param cause Exception cause
+     */
+    public ResourceNotFoundException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/test/java/com/artipie/maven/aether/AstoTransporterTest.java
+++ b/src/test/java/com/artipie/maven/aether/AstoTransporterTest.java
@@ -71,7 +71,11 @@ public final class AstoTransporterTest {
     public void implPeekShouldThrow() throws Exception {
         Assertions.assertThrows(
             ResourceNotFoundException.class,
-            () -> this.transporter.implPeek(new PeekTask(URI.create(UUID.randomUUID().toString())))
+            () -> this.transporter.implPeek(
+                new PeekTask(
+                    URI.create(this.randomString())
+                )
+            )
         );
     }
 

--- a/src/test/java/com/artipie/maven/aether/AstoTransporterTest.java
+++ b/src/test/java/com/artipie/maven/aether/AstoTransporterTest.java
@@ -1,0 +1,121 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.artipie.maven.aether;
+
+import com.artipie.asto.blocking.BlockingStorage;
+import com.artipie.asto.fs.FileStorage;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.UUID;
+import org.eclipse.aether.spi.connector.transport.GetTask;
+import org.eclipse.aether.spi.connector.transport.PeekTask;
+import org.eclipse.aether.spi.connector.transport.PutTask;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests for {@link AstoTransporter}.
+ * @since 0.1
+ */
+public final class AstoTransporterTest {
+
+    /**
+     * Test temporary directory.
+     * By JUnit annotation contract it should not be private
+     * @checkstyle VisibilityModifierCheck (3 lines)
+     */
+    @TempDir
+    Path temp;
+
+    /**
+     * Test class instance.
+     */
+    private AstoTransporter transporter;
+
+    @BeforeEach
+    public void before() {
+        this.transporter = new AstoTransporter(
+            new BlockingStorage(new FileStorage(this.temp))
+        );
+    }
+
+    @Test
+    public void implPeekShouldThrow() throws Exception {
+        Assertions.assertThrows(
+            ResourceNotFoundException.class,
+            () -> this.transporter.implPeek(new PeekTask(URI.create(UUID.randomUUID().toString())))
+        );
+    }
+
+    @Test
+    public void implPeekShouldNotThrow() throws Exception {
+        final var name = this.randomString();
+        Files.write(this.temp.resolve(name), new byte[0]);
+        Assertions.assertDoesNotThrow(
+            () -> this.transporter.implPeek(new PeekTask(URI.create(name)))
+        );
+    }
+
+    @Test
+    public void implGetShouldRead() throws Exception {
+        final var name = this.randomString();
+        final var content = this.randomString();
+        Files.write(this.temp.resolve(name), List.of(content));
+        final var task = new GetTask(URI.create(name));
+        this.transporter.implGet(task);
+        MatcherAssert.assertThat(
+            task.getDataString().trim(),
+            CoreMatchers.is(content)
+        );
+    }
+
+    @Test
+    public void implPutShouldWrite() throws Exception {
+        final var name = this.randomString();
+        final var content = this.randomString();
+        this.transporter.implPut(
+            new PutTask(URI.create(name))
+                .setDataString(content)
+        );
+        MatcherAssert.assertThat(
+            Files.readString(this.temp.resolve(name)),
+            CoreMatchers.is(content)
+        );
+    }
+
+    /**
+     * Generates random string.
+     * @return Random string.
+     */
+    private String randomString() {
+        return UUID.randomUUID().toString();
+    }
+}


### PR DESCRIPTION
issue #28 
Asto integration is done by implementing interfaces
`org.eclipse.aether.spi.connector.transport.TransporterFactory` and  `org.eclipse.aether.spi.connector.transport.Transporter` laying deeply in Maven services.
These services will be registered in a Service Locator in `com.artipie.maven.aether.ServiceLocatorFactory` and actual class usage will be introduced in `com.artipie.maven.aether.AetherRepository` in following pull requests.
