### PR TITLE
#30: configure ServiceLocatorFactory

### DIFF
--- a/src/main/java/com/artipie/maven/aether/AetherRepository.java
+++ b/src/main/java/com/artipie/maven/aether/AetherRepository.java
@@ -43,7 +43,6 @@ import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.deployment.DeployRequest;
 import org.eclipse.aether.deployment.DeployResult;
-import org.eclipse.aether.repository.LocalRepository;
 import org.eclipse.aether.spi.locator.ServiceLocator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -69,11 +68,6 @@ public final class AetherRepository implements Repository {
     private final ServiceLocatorFactory locators;
 
     /**
-     * Local repository.
-     */
-    private final LocalRepository repository;
-
-    /**
      * Staging files root.
      */
     private final AutoCloseablePath.Parent dir;
@@ -81,16 +75,13 @@ public final class AetherRepository implements Repository {
     /**
      * All args constructor.
      * @param locators Creates ServiceLocator instances
-     * @param repository Local repository
      * @param dir Staging files root
      */
     public AetherRepository(
         final ServiceLocatorFactory locators,
-        final LocalRepository repository,
         final AutoCloseablePath.Parent dir
     ) {
         this.locators = locators;
-        this.repository = repository;
         this.dir = dir;
     }
 
@@ -98,7 +89,7 @@ public final class AetherRepository implements Repository {
     public ArtifactMetadata upload(final String path, final InputStream content) throws Exception {
         final var coords = new FileCoordinates(path);
         final var locator = this.locators.serviceLocator();
-        final var session = new SessionFactory(this.repository, locator).newSession();
+        final var session = new SessionFactory(locator).newSession();
         final Artifact deployed = Iterables.getOnlyElement(
             new Deployer(locator, session)
                 .deploy(path, content)

--- a/src/main/java/com/artipie/maven/aether/SessionFactory.java
+++ b/src/main/java/com/artipie/maven/aether/SessionFactory.java
@@ -38,22 +38,15 @@ import org.eclipse.aether.spi.locator.ServiceLocator;
 public class SessionFactory {
 
     /**
-     * Local repository root.
-     */
-    private final LocalRepository repository;
-
-    /**
      * Maven service locator.
      */
     private final ServiceLocator services;
 
     /**
      * All args constructor.
-     * @param repository Local repository root
      * @param services Maven service locator
      */
-    public SessionFactory(final LocalRepository repository, final ServiceLocator services) {
-        this.repository = repository;
+    public SessionFactory(final ServiceLocator services) {
         this.services = services;
     }
 
@@ -62,16 +55,17 @@ public class SessionFactory {
      * @return A RepositorySystemSession instance
      */
     public RepositorySystemSession newSession() {
+        final var repository = this.services.getService(LocalRepository.class);
         try {
             final var session = MavenRepositorySystemUtils.newSession();
             session.setLocalRepositoryManager(
                 this.services.getService(LocalRepositoryManagerFactory.class)
-                    .newInstance(session, this.repository)
+                    .newInstance(session, repository)
             );
             return session;
         } catch (final NoLocalRepositoryManagerException ex) {
             throw new IllegalStateException(
-                String.format("with local repository %s", this.repository.getBasedir()),
+                String.format("with local repository %s", repository.getBasedir()),
                 ex
             );
         }

--- a/src/test/java/com/artipie/maven/aether/ServiceLocatorFactoryTest.java
+++ b/src/test/java/com/artipie/maven/aether/ServiceLocatorFactoryTest.java
@@ -24,8 +24,15 @@
 
 package com.artipie.maven.aether;
 
+import com.artipie.asto.fs.FileStorage;
+import java.nio.file.Path;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.repository.LocalRepository;
 import org.eclipse.aether.spi.connector.RepositoryConnectorFactory;
+import org.eclipse.aether.spi.connector.transport.TransporterFactory;
+import org.eclipse.aether.spi.localrepo.LocalRepositoryManagerFactory;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -35,13 +42,28 @@ import org.junit.jupiter.params.provider.ValueSource;
  */
 public final class ServiceLocatorFactoryTest {
 
+    /**
+     * Test temporary directory.
+     * By JUnit annotation contract it should not be private
+     * @checkstyle VisibilityModifierCheck (3 lines)
+     */
+    @TempDir
+    Path temp;
+
     @ParameterizedTest
     @ValueSource(classes = {
-        RepositoryConnectorFactory.class
+        RepositoryConnectorFactory.class,
+        RepositorySystem.class,
+        LocalRepositoryManagerFactory.class,
+        LocalRepository.class,
+        TransporterFactory.class
     })
     void shouldReturnService(final Class<?> service) {
         Assertions.assertNotNull(
-            new ServiceLocatorFactory().serviceLocator().getService(service)
+            new ServiceLocatorFactory(
+                new LocalRepository(this.temp.resolve("local").toFile()),
+                new FileStorage(this.temp.resolve("asto"))
+            ).serviceLocator().getService(service)
         );
     }
 }

--- a/src/test/java/com/artipie/maven/aether/SessionFactoryTest.java
+++ b/src/test/java/com/artipie/maven/aether/SessionFactoryTest.java
@@ -24,10 +24,12 @@
 
 package com.artipie.maven.aether;
 
-import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
+import com.artipie.asto.fs.FileStorage;
+import java.nio.file.Path;
 import org.eclipse.aether.repository.LocalRepository;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Tests for {@link SessionFactory}.
@@ -35,12 +37,22 @@ import org.junit.jupiter.api.Test;
  */
 public final class SessionFactoryTest {
 
+    /**
+     * Test temporary directory.
+     * By JUnit annotation contract it should not be private
+     * @checkstyle VisibilityModifierCheck (3 lines)
+     */
+    @TempDir
+    Path temp;
+
     @Test
     public void shouldConfigureSession() {
         Assertions.assertNotNull(
             new SessionFactory(
-                new LocalRepository("."),
-                MavenRepositorySystemUtils.newServiceLocator()
+                new ServiceLocatorFactory(
+                    new LocalRepository(this.temp.resolve("local").toFile()),
+                    new FileStorage(this.temp.resolve("asto"))
+                ).serviceLocator()
             )
                 .newSession()
                 .getLocalRepositoryManager()


### PR DESCRIPTION
issue #30

To pass as constructor args:
- `org.eclipse.aether.repository.LocalRepository` - to locate it directly from ServiceLocator.
- `com.artipie.maven.aether.AstoTransporterFactory` - to actually use it in `AetherRepository`.