### PR TITLE
#35: read checksum attribute file

### DIFF
--- a/src/main/java/com/artipie/maven/ChecksumAttribute.java
+++ b/src/main/java/com/artipie/maven/ChecksumAttribute.java
@@ -25,23 +25,28 @@
 package com.artipie.maven;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
-import java.security.DigestOutputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.EnumMap;
 import java.util.Locale;
-import java.util.Map;
+import java.util.Optional;
 import org.apache.commons.codec.binary.Hex;
-import org.apache.commons.io.output.NullOutputStream;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Encapsulates checksum file logic.
  * @since 0.1
  */
 public final class ChecksumAttribute {
+
+    /**
+     * Class logger.
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(ChecksumAttribute.class);
 
     /**
      * File to calculate checksums for.
@@ -54,38 +59,6 @@ public final class ChecksumAttribute {
      */
     public ChecksumAttribute(final Path path) {
         this.path = path;
-    }
-
-    /**
-     * Calculates checksums and writes them to corresponding files.
-     * @return Map of HEX-encoded checksums per algorithms
-     * @throws IOException File reading failed
-     * @throws NoSuchAlgorithmException Invalid {@link ChecksumType}
-     */
-    public Map<ChecksumType, String> write() throws IOException, NoSuchAlgorithmException {
-        final Map<ChecksumType, String> map = new EnumMap<>(ChecksumType.class);
-        for (final ChecksumType type : ChecksumType.values()) {
-            map.put(type, this.write(type));
-        }
-        return map;
-    }
-
-    /**
-     * Calculates checksum for a given type and writes it to a corresponding file.
-     * @param type Checksum type
-     * @return Map of HEX-encoded checksums per algorithms
-     * @throws IOException File reading failed
-     * @throws NoSuchAlgorithmException Invalid {@link ChecksumType}
-     */
-    public String write(final ChecksumType type) throws IOException, NoSuchAlgorithmException {
-        final var hex = this.readHex(type);
-        Files.writeString(
-            this.resolveName(type),
-            hex,
-            StandardOpenOption.TRUNCATE_EXISTING,
-            StandardOpenOption.CREATE
-        );
-        return hex;
     }
 
     /**
@@ -104,17 +77,55 @@ public final class ChecksumAttribute {
     }
 
     /**
-     * Calculates a checksum for a path.
+     * Reads a checksum for a path.
      * @param type Checksum algorithm
      * @return HEX-encoded checksum
-     * @throws IOException File reading failed
      * @throws NoSuchAlgorithmException Invalid {@link ChecksumType}
      */
-    public String readHex(final ChecksumType type) throws IOException, NoSuchAlgorithmException {
+    public String readHex(final ChecksumType type) throws NoSuchAlgorithmException {
+        final var digest = MessageDigest.getInstance(type.algorithm());
+        return this.readAttribute(type)
+            .orElseGet(() -> this.calcHex(digest));
+    }
+
+    /**
+     * Tries to read a checksum attribute file.
+     * @param type Checksum file
+     * @return Present hex-encoded checksum if attribute exists.
+     */
+    private Optional<String> readAttribute(final ChecksumType type) {
+        return Optional.of(this.resolveName(type))
+            .filter(
+                file -> {
+                    final var exists = Files.exists(file);
+                    if (!exists) {
+                        LOG.warn("checksum file does not exist {}", file);
+                    }
+                    return exists;
+                }
+            ).map(
+                file -> {
+                    try {
+                        return Files.readString(file);
+                    } catch (final IOException ex) {
+                        throw new UncheckedIOException(ex);
+                    }
+                }
+            );
+    }
+
+    /**
+     * Calculates a checksum for a path.
+     * @param digest MessageDigest
+     * @return HEX-encoded checksum
+     */
+    private String calcHex(final MessageDigest digest) {
         try (var read = Files.newInputStream(this.path)) {
-            final var digest = MessageDigest.getInstance(type.algorithm());
-            read.transferTo(new DigestOutputStream(new NullOutputStream(), digest));
-            return Hex.encodeHexString(digest.digest());
+            return Hex.encodeHexString(
+                DigestUtils.digest(digest, read)
+            );
+        } catch (final IOException ex) {
+            throw new UncheckedIOException(ex);
         }
     }
 }

--- a/src/test/java/com/artipie/maven/ChecksumAttributeTest.java
+++ b/src/test/java/com/artipie/maven/ChecksumAttributeTest.java
@@ -97,12 +97,13 @@ public final class ChecksumAttributeTest {
 
     @ParameterizedTest
     @EnumSource(ChecksumType.class)
-    public void shouldReadAttributeFile(final ChecksumType type) throws Exception {
+    public void shouldReadChecksumFromFile(final ChecksumType type) throws Exception {
         final var path = this.randomFile();
         final var checksum = new ChecksumAttribute(path);
         final var line = this.randomString();
         Files.writeString(checksum.resolveName(type), line);
         MatcherAssert.assertThat(
+            "should read checksum from checksum file",
             checksum.readHex(type),
             new IsEqual<>(line)
         );

--- a/src/test/java/com/artipie/maven/ChecksumAttributeTest.java
+++ b/src/test/java/com/artipie/maven/ChecksumAttributeTest.java
@@ -27,12 +27,16 @@ package com.artipie.maven;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.MessageDigest;
-import java.util.Locale;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.codec.digest.DigestUtils;
-import org.junit.jupiter.api.Assertions;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.AllOf;
+import org.hamcrest.core.IsEqual;
+import org.hamcrest.core.StringEndsWith;
+import org.hamcrest.core.StringStartsWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -48,55 +52,74 @@ public final class ChecksumAttributeTest {
      */
     private static final int ARRAY_LENGTH = 8192;
 
-    // @checkstyle VisibilityModifierCheck (5 lines)
     /**
-     * Temporary directory.
+     * Test temporary directory.
+     * By JUnit annotation contract it should not be private
+     * @checkstyle VisibilityModifierCheck (3 lines)
      */
     @TempDir
     Path temp;
 
     @ParameterizedTest
     @EnumSource(ChecksumType.class)
-    public void testResolveName(final ChecksumType type) throws Exception {
-        final var path = this.random();
-        Assertions.assertEquals(
-            path.resolveSibling(
-                String.join(
-                    ".",
-                    path.getFileName().toString(),
-                    type.name().toLowerCase(Locale.getDefault())
-                )
-            ),
+    public void shouldResolveName(final ChecksumType type) throws Exception {
+        final var path = this.randomFile();
+        MatcherAssert.assertThat(
+            "ChecksumAttribute should resolve attribute path",
             new ChecksumAttribute(path)
                 .resolveName(type)
+                .toString(),
+            new AllOf<>(
+                List.of(
+                    new StringStartsWith(false, path.toString()),
+                    new StringEndsWith(true, type.toString())
+                )
+            )
         );
     }
 
     @ParameterizedTest
     @EnumSource(ChecksumType.class)
-    public void testReadHex(final ChecksumType type) throws Exception {
-        final var path = this.random();
-        try (var stream = Files.newInputStream(path)) {
-            Assertions.assertEquals(
+    public void shouldCalcChecksum(final ChecksumType type) throws Exception {
+        final var path = this.randomFile();
+        MatcherAssert.assertThat(
+            "checksums should match",
+            new ChecksumAttribute(path).readHex(type),
+            new IsEqual<>(
                 Hex.encodeHexString(
                     DigestUtils.digest(
-                        MessageDigest.getInstance(type.algorithm()),
-                        stream
+                        MessageDigest.getInstance(type.algorithm()), path.toFile()
                     )
-                ),
-                new ChecksumAttribute(path).readHex(type)
-            );
-        }
+                )
+            )
+        );
     }
 
-    private Path random() throws Exception {
+    @ParameterizedTest
+    @EnumSource(ChecksumType.class)
+    public void shouldReadAttributeFile(final ChecksumType type) throws Exception {
+        final var path = this.randomFile();
+        final var checksum = new ChecksumAttribute(path);
+        final var line = this.randomString();
+        Files.writeString(checksum.resolveName(type), line);
+        MatcherAssert.assertThat(
+            checksum.readHex(type),
+            new IsEqual<>(line)
+        );
+    }
+
+    private Path randomFile() throws Exception {
         final var bytes = new byte[ChecksumAttributeTest.ARRAY_LENGTH];
         ThreadLocalRandom.current().nextBytes(bytes);
         return Files.write(
             this.temp.resolve(
-                String.format("%s.bin", UUID.randomUUID().toString())
+                String.format("%s.bin", this.randomString())
             ),
             bytes
         );
+    }
+
+    private String randomString() {
+        return UUID.randomUUID().toString();
     }
 }


### PR DESCRIPTION
issue #35 
- writing checksums is no longer required, Maven library does it for you;
- reading checksums from checksum files, now it calculates directly from an artifact;
- migrate a unit test from JUnit assertions to Hamcrest assertions.