### PR TITLE
#36: Repository upload with reactive interface

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>com.artipie</groupId>
             <artifactId>asto</artifactId>
-            <version>0.13.0</version>
+            <version>0.13.3</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/src/main/java/com/artipie/maven/aether/AstoTransporter.java
+++ b/src/main/java/com/artipie/maven/aether/AstoTransporter.java
@@ -33,12 +33,19 @@ import org.eclipse.aether.spi.connector.transport.PeekTask;
 import org.eclipse.aether.spi.connector.transport.PutTask;
 import org.eclipse.aether.spi.connector.transport.TransportTask;
 import org.eclipse.aether.spi.connector.transport.Transporter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Adapts Asto to {@link Transporter}.
  * @since 0.1
  */
 public final class AstoTransporter extends AbstractTransporter {
+
+    /**
+     * Class logger.
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(AstoTransporter.class);
 
     /**
      * Asto.
@@ -69,17 +76,21 @@ public final class AstoTransporter extends AbstractTransporter {
 
     @Override
     public void implGet(final GetTask task) throws Exception {
+        LOG.debug("implGet start {}", task.getLocation().toString());
         this.exists(task);
         try (var write = task.newOutputStream()) {
             IOUtils.write(this.asto.value(new TaskKey(task).key()), write);
         }
+        LOG.debug("implGet finish {}", task.getLocation().toString());
     }
 
     @Override
     public void implPut(final PutTask task) throws Exception {
+        LOG.debug("implPut start {}", task.getLocation().toString());
         try (var read = task.newInputStream()) {
             this.asto.save(new TaskKey(task).key(), IOUtils.toByteArray(read));
         }
+        LOG.debug("implPut finish {}", task.getLocation().toString());
     }
 
     @Override
@@ -95,6 +106,7 @@ public final class AstoTransporter extends AbstractTransporter {
     private void exists(final TransportTask task) {
         final Key key = new TaskKey(task).key();
         if (!this.asto.exists(key)) {
+            LOG.debug("does not exist {}", task.getLocation().toString());
             throw new ResourceNotFoundException(
                 String.format(
                     "Resource does not exist in Asto: key %s and location %s",

--- a/src/main/java/com/artipie/maven/aether/repository/Deployer.java
+++ b/src/main/java/com/artipie/maven/aether/repository/Deployer.java
@@ -24,6 +24,7 @@
 
 package com.artipie.maven.aether.repository;
 
+import com.artipie.asto.fs.RxFile;
 import com.artipie.maven.ArtifactMetadata;
 import com.artipie.maven.ChecksumAttribute;
 import com.artipie.maven.ChecksumType;
@@ -32,24 +33,33 @@ import com.artipie.maven.FileCoordinates;
 import com.artipie.maven.aether.LocalArtifactResolver;
 import com.artipie.maven.aether.RemoteRepositories;
 import com.artipie.maven.util.AutoCloseablePath;
-import com.artipie.maven.util.FileCleanupException;
-import com.google.common.collect.Iterables;
-import java.io.InputStream;
+import io.reactivex.Flowable;
+import io.reactivex.Single;
+import io.reactivex.functions.Consumer;
+import io.reactivex.functions.Function;
+import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.NoSuchAlgorithmException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Flow;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.deployment.DeployRequest;
-import org.eclipse.aether.deployment.DeployResult;
+import org.eclipse.aether.deployment.DeploymentException;
 import org.eclipse.aether.installation.InstallRequest;
+import org.eclipse.aether.installation.InstallationException;
+import org.reactivestreams.FlowAdapters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * Performs deployment lifecycle in terms of Maven libraries.
  * @since 0.1
+ * @checkstyle ClassDataAbstractionCouplingCheck (200 lines) see {@link AetherRepository} javadoc
  */
 final class Deployer {
 
@@ -57,6 +67,12 @@ final class Deployer {
      * Using another class logger.
      */
     private static final Logger LOG = LoggerFactory.getLogger(AetherRepository.class);
+
+    /**
+     * If false then the resource closing will be deferred until the stream termination.
+     * @see Single#using(Callable, Function, Consumer, boolean)
+     */
+    private static final boolean DEFERRED_CLOSE = false;
 
     /**
      * Remote repositories to handle artifacts.
@@ -105,45 +121,85 @@ final class Deployer {
      * @return DeployResult
      * @throws Exception Deployment failed
      */
-    public ArtifactMetadata deploy(
+    public Single<ArtifactMetadata> deploy(
         final String path,
-        final InputStream content
-    ) throws Exception {
+        final Flow.Publisher<ByteBuffer> content
+    ) {
         final var coords = new FileCoordinates(path);
-        DeployResult result = null;
-        try (var staging = this.dir.resolve(path)) {
-            try (var file = Files.newOutputStream(staging.unwrap())) {
-                content.transferTo(file);
-            }
-            final var artifact = new DefaultArtifact(
-                coords.coords()
-            ).setFile(
-                staging.unwrap().toFile()
-            );
-            this.repositories.install(
-                this.session,
-                new InstallRequest().addArtifact(artifact)
-            );
-            result = this.repositories.deploy(
-                this.session,
-                new DeployRequest()
-                    .addArtifact(artifact)
-                    .setRepository(
-                        this.remotes.uploading(coords)
-                    )
-            );
-        } catch (final FileCleanupException ex) {
-            LOG.warn("on AutoCloseablePath cleanup", ex);
-        }
-        final Artifact deployed = Iterables.getOnlyElement(
-            result.getArtifacts()
+        LOG.debug("deploying coords {}", coords);
+        return this.staging(coords, content)
+            .map(file -> new DefaultArtifact(coords.coords()).setFile(file.toFile()))
+            .doOnSuccess(artifact -> this.install(artifact))
+            .doOnSuccess(artifact -> this.deploy(coords, artifact))
+            .map(artifact -> this.result(coords, artifact));
+    }
+
+    /**
+     * Wraps subsequent operators with staging file.
+     * @param coords Artifact coords
+     * @param content Artifact binary
+     * @return Staging file path
+     */
+    private Single<Path> staging(
+        final FileCoordinates coords,
+        final Flow.Publisher<ByteBuffer> content
+    ) {
+        return Single.using(
+            () -> this.dir.resolve(coords.path()),
+            staging -> new RxFile(staging.unwrap())
+                .save(Flowable.fromPublisher(FlowAdapters.toPublisher(content)))
+                .andThen(Single.defer(() -> Single.just(staging.unwrap()))),
+            AutoCloseablePath::close,
+            Deployer.DEFERRED_CLOSE
         );
+    }
+
+    /**
+     * Installs given artifact to a local repository.
+     * @param artifact An artifact to install
+     * @throws InstallationException Installation failed
+     */
+    private void install(final Artifact artifact) throws InstallationException {
+        LOG.debug("installing {}", artifact);
+        this.repositories.install(
+            this.session,
+            new InstallRequest().addArtifact(artifact)
+        );
+    }
+
+    /**
+     * Deploys given artifact from a local repository to a remote repository.
+     * @param coords Artifact coordinates
+     * @param artifact Artifact itself
+     * @throws DeploymentException If deployment failed
+     */
+    private void deploy(final FileCoordinates coords, final Artifact artifact)
+        throws DeploymentException {
+        LOG.debug("deploying {}", artifact);
+        this.repositories.deploy(
+            this.session,
+            new DeployRequest()
+                .addArtifact(artifact)
+                .setRepository(this.remotes.uploading(coords))
+        );
+    }
+
+    /**
+     * Creates {@link ArtifactMetadata} instance.
+     * @param coords Artifact coordinates
+     * @param artifact Artifact instance
+     * @return Resulting ArtifactMetadata
+     * @throws IOException If reading from a local repository failed
+     * @throws NoSuchAlgorithmException ChecksumType misconfiguration
+     */
+    private ArtifactMetadata result(final FileCoordinates coords, final Artifact artifact)
+        throws IOException, NoSuchAlgorithmException {
         final Path file = new LocalArtifactResolver(this.session)
-            .resolve(deployed);
+            .resolve(artifact);
         final var checksums = new ChecksumAttribute(file);
         return new DetachedMetadata(
             coords,
-            path,
+            coords.path(),
             Files.size(file),
             checksums.readHex(ChecksumType.MD5),
             checksums.readHex(ChecksumType.SHA1)

--- a/src/test/java/com/artipie/maven/aether/repository/DeployerTest.java
+++ b/src/test/java/com/artipie/maven/aether/repository/DeployerTest.java
@@ -42,6 +42,7 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
 import org.reactivestreams.FlowAdapters;
 
@@ -49,7 +50,9 @@ import org.reactivestreams.FlowAdapters;
  * Tests for {@link Deployer}.
  * @since 0.1
  * @checkstyle ClassDataAbstractionCouplingCheck (60 lines)
+ * @checkstyle MagicNumberCheck (2 lines)
  */
+@Timeout(5)
 public final class DeployerTest {
 
     /**

--- a/src/test/java/com/artipie/maven/aether/repository/DeployerTest.java
+++ b/src/test/java/com/artipie/maven/aether/repository/DeployerTest.java
@@ -22,30 +22,35 @@
  * SOFTWARE.
  */
 
-package com.artipie.maven.aether;
+package com.artipie.maven.aether.repository;
 
 import com.artipie.asto.Key;
 import com.artipie.asto.blocking.BlockingStorage;
 import com.artipie.asto.fs.FileStorage;
-import com.artipie.maven.Repository;
-import com.artipie.maven.aether.repository.AetherRepository;
+import com.artipie.maven.aether.ServiceLocatorFactory;
+import com.artipie.maven.aether.SessionFactory;
+import com.artipie.maven.aether.SimpleRemoteRepositories;
 import com.artipie.maven.util.AutoCloseablePath;
-import java.io.ByteArrayInputStream;
+import io.reactivex.Flowable;
+import java.nio.ByteBuffer;
 import java.nio.file.Path;
+import java.util.concurrent.Flow;
 import org.apache.commons.codec.digest.DigestUtils;
+import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.repository.LocalRepository;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.reactivestreams.FlowAdapters;
 
 /**
- * Tests for {@link AetherRepository}.
+ * Tests for {@link Deployer}.
  * @since 0.1
  * @checkstyle ClassDataAbstractionCouplingCheck (60 lines)
  */
-public final class AetherRepositoryTest {
+public final class DeployerTest {
 
     /**
      * Test temporary directory.
@@ -61,26 +66,32 @@ public final class AetherRepositoryTest {
     private BlockingStorage asto;
 
     /**
-     * Maven adapter.
+     * The class under test.
      */
-    private Repository repository;
+    private Deployer deployer;
 
     @BeforeEach
     public void before() {
         final FileStorage files = new FileStorage(this.temp.resolve("asto"));
         this.asto = new BlockingStorage(files);
-        this.repository = new AetherRepository(
-            new ServiceLocatorFactory(files),
-            new LocalRepository(this.temp.resolve("local").toFile()),
+        final var locator = new ServiceLocatorFactory(files).serviceLocator();
+        this.deployer = new Deployer(
+            new SimpleRemoteRepositories(),
             new AutoCloseablePath.Parent(this.temp.resolve("staging")),
-            new SimpleRemoteRepositories()
+            locator.getService(RepositorySystem.class),
+            new SessionFactory(
+                new LocalRepository(this.temp.resolve("local").toFile()),
+                locator
+            ).newSession()
         );
     }
 
     @Test
     public void shouldStoreArtifact() throws Exception {
         final var path = "example/artifact/1.0/artifact-1.0.jar";
-        this.repository.upload(path, new ByteArrayInputStream(new byte[0]));
+        this.deployer.deploy(path, this.flow(new byte[0]))
+            .ignoreElement()
+            .blockingAwait();
         MatcherAssert.assertThat(
             "should create the file in Asto",
             this.asto.exists(new Key.From(path)),
@@ -92,7 +103,7 @@ public final class AetherRepositoryTest {
     public void shouldMatchChecksums() throws Exception {
         final var path = "example/artifact/1.0/artifact-1.0.pom";
         final var bytes = new byte[0];
-        final var artifact = this.repository.upload(path, new ByteArrayInputStream(bytes));
+        final var artifact = this.deployer.deploy(path, this.flow(bytes)).blockingGet();
         MatcherAssert.assertThat(
             "checksums should match",
             artifact.sha1(),
@@ -103,7 +114,9 @@ public final class AetherRepositoryTest {
     @Test
     public void shouldUpload() throws Exception {
         final var path = "org/example/artifact/1.0/artifact-1.0.jar";
-        this.repository.upload(path, new ByteArrayInputStream(new byte[0]));
+        this.deployer.deploy(path, this.flow(new byte[0]))
+            .ignoreElement()
+            .blockingAwait();
         MatcherAssert.assertThat(
             "should create a metadata file",
             this.asto.exists(
@@ -115,5 +128,11 @@ public final class AetherRepositoryTest {
             ),
             new IsEqual<>(true)
         );
+    }
+
+    private Flow.Publisher<ByteBuffer> flow(final byte[] bytes) {
+        return Flowable.fromArray(bytes)
+            .map(ByteBuffer::wrap)
+            .to(FlowAdapters::toFlowPublisher);
     }
 }

--- a/src/test/java/com/artipie/maven/aether/repository/package-info.java
+++ b/src/test/java/com/artipie/maven/aether/repository/package-info.java
@@ -22,30 +22,12 @@
  * SOFTWARE.
  */
 
-package com.artipie.maven;
-
-import java.nio.ByteBuffer;
-import java.util.concurrent.Flow;
-
 /**
- * General abstraction over Maven (remote) repository.
- *
+ * A package for {@link com.artipie.maven.aether.repository.AetherRepository} and related classes.
  * @since 0.1
  */
-public interface Repository {
-
-    /**
-     * Downloads given artifact.
-     * @param path Artifact URI path
-     * @return File payload
-     */
-    Flow.Publisher<ByteBuffer> download(String path);
-
-    /**
-     * Uploads given artifact.
-     * @param path Artifact URI path segment
-     * @param content Artifact binary
-     * @return Artifact metadata
-     */
-    Flow.Publisher<ArtifactMetadata> deploy(String path, Flow.Publisher<ByteBuffer> content);
-}
+/**
+ * Tests for respective package.
+ * @since 0.1
+ */
+package com.artipie.maven.aether.repository;


### PR DESCRIPTION
issue #36 BTW reactive approach makes uploading lifecycle clearer.
`Deployer` class javadoc has a qulice suppression, explained in `AetherRepository`.