### PR TITLE
Repository returns content instead of response

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>http</artifactId>
-      <version>0.8.4</version>
+      <version>0.9.7</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>

--- a/src/main/java/com/artipie/maven/repository/ArtifactNotFoundException.java
+++ b/src/main/java/com/artipie/maven/repository/ArtifactNotFoundException.java
@@ -21,25 +21,30 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package com.artipie.maven.http;
+package com.artipie.maven.repository;
 
-import com.artipie.http.Slice;
-import com.artipie.maven.repository.RpRemote;
-import java.net.URI;
-import org.eclipse.jetty.client.HttpClient;
+import com.artipie.asto.Key;
 
 /**
- * Maven proxy repository slice.
+ * This exception can be thrown when artifact was not found.
  * @since 0.5
  */
-public final class MavenProxySlice extends Slice.Wrap {
+@SuppressWarnings("serial")
+public final class ArtifactNotFoundException extends IllegalStateException {
 
     /**
-     * Proxy for URI.
-     * @param http Http client
-     * @param uri URI
+     * New exception with artifact key.
+     * @param artifact Artifact key
      */
-    public MavenProxySlice(final HttpClient http, final URI uri) {
-        super(new DownloadMavenSlice(new RpRemote(http, uri)));
+    public ArtifactNotFoundException(final Key artifact) {
+        this(String.format("Artifact '%s' was not found", artifact.string()));
+    }
+
+    /**
+     * New exception with message.
+     * @param msg Message
+     */
+    public ArtifactNotFoundException(final String msg) {
+        super(msg);
     }
 }

--- a/src/main/java/com/artipie/maven/repository/Repository.java
+++ b/src/main/java/com/artipie/maven/repository/Repository.java
@@ -23,8 +23,10 @@
  */
 package com.artipie.maven.repository;
 
+import com.artipie.asto.Content;
 import com.artipie.http.Response;
 import java.net.URI;
+import java.util.concurrent.CompletionStage;
 
 /**
  * A Maven repository that abstracts over local, remote, etc, types of repository.
@@ -42,10 +44,6 @@ import java.net.URI;
  *  should ultimately be a configuration file as explained in #92 for instantiating
  *  Repositories. See #92 for more details on this. Don't hesitate to ask ARC about
  *  it since this todo is quite complex.
- * @todo #92:30min For now this interface returns a Response but it should instead
- *  only answer with the ByteBuffer of the artifact found in the repository. The challenge
- *  here is that some of the current implementations of Repository takes care of answering
- *  404 when the artifact is not present: this responsibility should be moved to RepositorySlice.
  */
 public interface Repository {
 
@@ -53,7 +51,7 @@ public interface Repository {
      * Build a {@link Response} for a GET request to serve a Maven artifact.
      *
      * @param uri The requested artifact
-     * @return The response.
+     * @return Artifact data content future
      */
-    Response response(URI uri);
+    CompletionStage<Content> artifact(URI uri);
 }


### PR DESCRIPTION
#96 - returns `Content` from `Repository` instead of `Response`. Moved HTTP logic to `Slice` level.