### PR TITLE
#113 - introduced ValidUpload abstraction

### DIFF
--- a/src/main/java/com/artipie/maven/Maven.java
+++ b/src/main/java/com/artipie/maven/Maven.java
@@ -49,6 +49,9 @@ import org.xembly.Directives;
  *  If we found some unsupported algorithm, then delete checksum file. I'd start with
  *  `MD5`, `SHA-256`, `SHA-1` and `SHA-512`. After this, enable testes in
  *  MavenTest.
+ * @todo #113:30min Extract interface from this class, this class should become main implementation.
+ *  Also create `Fake` implementation for test purposes and add test method to
+ *  `UpdateMavenSliceTest` to verify that UpdateMavenSlice calls `Maven#update` on update.
  */
 public final class Maven {
 

--- a/src/main/java/com/artipie/maven/http/UpdateMavenSlice.java
+++ b/src/main/java/com/artipie/maven/http/UpdateMavenSlice.java
@@ -23,20 +23,22 @@
  */
 package com.artipie.maven.http;
 
+import com.artipie.asto.Content;
 import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
-import com.artipie.http.Connection;
 import com.artipie.http.Response;
 import com.artipie.http.Slice;
+import com.artipie.http.async.AsyncResponse;
 import com.artipie.http.rq.RequestLineFrom;
-import com.artipie.http.slice.SliceUpload;
+import com.artipie.http.rs.RsStatus;
+import com.artipie.http.rs.RsWithStatus;
+import com.artipie.http.slice.KeyFromPath;
 import com.artipie.maven.Maven;
 import com.artipie.maven.repository.ValidUpload;
 import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.reactivestreams.Publisher;
@@ -47,6 +49,7 @@ import org.reactivestreams.Publisher;
  * Starts metadata update after {@code maven-metadata.xml} upload.
  * </p>
  * @since 0.4
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 final class UpdateMavenSlice implements Slice {
 
@@ -96,65 +99,39 @@ final class UpdateMavenSlice implements Slice {
         final RequestLineFrom reqline = new RequestLineFrom(line);
         final String path = reqline.uri().getPath();
         final Matcher matcher = PTN_META.matcher(path);
-        return new ResponseWrap(
-            new SliceUpload(this.storage).response(line, head, body),
-            () -> {
-                final CompletionStage<Void> res;
-                if (matcher.matches()) {
-                    final Key location = new Key.From(matcher.group("pkg"));
-                    res = this.validator.validate(location).thenCompose(
-                        valid -> {
-                            final CompletionStage<Void> upd;
-                            if (valid) {
-                                upd = this.maven.update(location);
-                            } else {
-                                upd = this.storage.list(location).thenCompose(
-                                    items -> CompletableFuture.allOf(
-                                        items.stream().map(this.storage::delete)
-                                            .toArray(CompletableFuture[]::new)
-                                    )
-                                );
+        return new AsyncResponse(
+            this.storage.save(
+                new KeyFromPath(new RequestLineFrom(line).uri().getPath()), new Content.From(body)
+            ).thenCompose(
+                ignored -> {
+                    final CompletionStage<Response> res;
+                    if (matcher.matches()) {
+                        final Key location = new Key.From(matcher.group("pkg"));
+                        res = this.validator.validate(location).thenCompose(
+                            valid -> {
+                                final CompletionStage<Response> upd;
+                                if (valid) {
+                                    upd = this.maven.update(location)
+                                        .thenApply(nothing -> new RsWithStatus(RsStatus.CREATED));
+                                } else {
+                                    upd = this.storage.list(location).thenCompose(
+                                        items -> CompletableFuture.allOf(
+                                            items.stream().map(this.storage::delete)
+                                                .toArray(CompletableFuture[]::new)
+                                        )
+                                    ).thenApply(
+                                        nothing -> new RsWithStatus(RsStatus.BAD_REQUEST)
+                                    );
+                                }
+                                return upd;
                             }
-                            return upd;
-                        }
-                    );
-                } else {
-                    res = CompletableFuture.completedFuture(null);
+                        );
+                    } else {
+                        res = CompletableFuture.completedFuture(new RsWithStatus(RsStatus.CREATED));
+                    }
+                    return res;
                 }
-                return res;
-            }
+            )
         );
-    }
-
-    /**
-     * Response decorator which starts task after response.
-     * @since 0.4
-     */
-    private static final class ResponseWrap implements Response {
-
-        /**
-         * Origin response.
-         */
-        private final Response origin;
-
-        /**
-         * Update task.
-         */
-        private final Supplier<CompletionStage<Void>> update;
-
-        /**
-         * Ctor.
-         * @param response Origin response
-         * @param update Update task
-         */
-        ResponseWrap(final Response response, final Supplier<CompletionStage<Void>> update) {
-            this.origin = response;
-            this.update = update;
-        }
-
-        @Override
-        public CompletionStage<Void> send(final Connection connection) {
-            return this.origin.send(connection).thenCompose(none -> this.update.get());
-        }
     }
 }

--- a/src/main/java/com/artipie/maven/repository/ValidUpload.java
+++ b/src/main/java/com/artipie/maven/repository/ValidUpload.java
@@ -1,0 +1,81 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.maven.repository;
+
+import com.artipie.asto.Key;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Valid upload to maven repository.
+ * @since 0.5
+ * @todo #113:30min Implement this interface: proper implementation should validate artifact being
+ *  uploaded to storage by checking checksums and metadata file. Do not forget about test.
+ */
+public interface ValidUpload {
+
+    /**
+     * Validate upload:
+     * - validate upload checksums;
+     * - validate metadata: check metadata group and id are the same as in
+     * repository metadata, metadata versions are correct.
+     * @param location Upload artifact files location
+     * @return Completable validation action: true if uploaded maven-metadata.xml is valid,
+     *  false otherwise
+     */
+    CompletionStage<Boolean> validate(Key location);
+
+    /**
+     * Dummy {@link ValidUpload} implementation.
+     * @since 0.5
+     */
+    final class Dummy implements ValidUpload {
+
+        /**
+         * Validation result.
+         */
+        private final boolean res;
+
+        /**
+         * Ctor.
+         * @param res Result of the validation
+         */
+        public Dummy(final boolean res) {
+            this.res = res;
+        }
+
+        /**
+         * Ctor.
+         */
+        public Dummy() {
+            this(true);
+        }
+
+        @Override
+        public CompletionStage<Boolean> validate(final Key location) {
+            return CompletableFuture.completedFuture(this.res);
+        }
+    }
+
+}

--- a/src/test/java/com/artipie/maven/http/UpdateMavenSliceTest.java
+++ b/src/test/java/com/artipie/maven/http/UpdateMavenSliceTest.java
@@ -75,13 +75,13 @@ class UpdateMavenSliceTest {
         final byte[] body = "java metadata".getBytes();
         final String location = "org/example/artifact/0.1/maven-metadata.xml";
         MatcherAssert.assertThat(
-            "Returns CREATED status",
+            "Returns BAD_REQUEST status",
             new UpdateMavenSlice(storage, new ValidUpload.Dummy(false)).response(
                 new RequestLine("PUT", String.format("/%s", location)).toString(),
                 Collections.emptyList(),
                 Flowable.fromArray(ByteBuffer.wrap(body))
             ),
-            new RsHasStatus(RsStatus.CREATED)
+            new RsHasStatus(RsStatus.BAD_REQUEST)
         );
         MatcherAssert.assertThat(
             "Storage is empty",

--- a/src/test/java/com/artipie/maven/http/UpdateMavenSliceTest.java
+++ b/src/test/java/com/artipie/maven/http/UpdateMavenSliceTest.java
@@ -1,0 +1,93 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.maven.http;
+
+import com.artipie.asto.Key;
+import com.artipie.asto.Storage;
+import com.artipie.asto.ext.PublisherAs;
+import com.artipie.asto.memory.InMemoryStorage;
+import com.artipie.http.hm.RsHasStatus;
+import com.artipie.http.rq.RequestLine;
+import com.artipie.http.rs.RsStatus;
+import com.artipie.maven.repository.ValidUpload;
+import io.reactivex.Flowable;
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.collection.IsEmptyIterable;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test for {@link UpdateMavenSlice}.
+ * @since 0.5
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+class UpdateMavenSliceTest {
+
+    @Test
+    void uploadsFile() {
+        final Storage storage = new InMemoryStorage();
+        final byte[] body = "java code".getBytes();
+        final String location = "org/example/artifact/0.1/artifact-1.0.jar";
+        MatcherAssert.assertThat(
+            "Returns CREATED status",
+            new UpdateMavenSlice(storage).response(
+                new RequestLine("PUT", String.format("/%s", location)).toString(),
+                Collections.emptyList(),
+                Flowable.fromArray(ByteBuffer.wrap(body))
+            ),
+            new RsHasStatus(RsStatus.CREATED)
+        );
+        MatcherAssert.assertThat(
+            "Puts file to storage",
+            new PublisherAs(storage.value(new Key.From(location)).join())
+                .bytes().toCompletableFuture().join(),
+            new IsEqual<>(body)
+        );
+    }
+
+    @Test
+    void removesArtifactIfUploadIsInvalid() {
+        final Storage storage = new InMemoryStorage();
+        final byte[] body = "java metadata".getBytes();
+        final String location = "org/example/artifact/0.1/maven-metadata.xml";
+        MatcherAssert.assertThat(
+            "Returns CREATED status",
+            new UpdateMavenSlice(storage, new ValidUpload.Dummy(false)).response(
+                new RequestLine("PUT", String.format("/%s", location)).toString(),
+                Collections.emptyList(),
+                Flowable.fromArray(ByteBuffer.wrap(body))
+            ),
+            new RsHasStatus(RsStatus.CREATED)
+        );
+        MatcherAssert.assertThat(
+            "Storage is empty",
+            storage.list(Key.ROOT).join(),
+            new IsEmptyIterable<>()
+        );
+    }
+
+}


### PR DESCRIPTION
Part of #113 
- introduced `ValidUpload` abstraction and `Dummy` implementation
- used this new abstraction in `UpdateMavenSlice`
- created test for `UpdateMavenSlice`
- added todos to continue