### PR TITLE
#124 - extract interface from `Maven`

### DIFF
--- a/src/main/java/com/artipie/maven/AstoMaven.java
+++ b/src/main/java/com/artipie/maven/AstoMaven.java
@@ -1,0 +1,105 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.maven;
+
+import com.artipie.asto.Concatenation;
+import com.artipie.asto.Key;
+import com.artipie.asto.Remaining;
+import com.artipie.asto.Storage;
+import com.jcabi.xml.XMLDocument;
+import hu.akarnokd.rxjava2.interop.SingleInterop;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
+import org.xembly.Directives;
+
+/**
+ * Maven front for artipie maven adaptor.
+ *
+ * @since 0.2
+ * @todo #91:30min Generate valid checksums on metadata update.
+ *  When updating the maven-metadata.xml, then we should find all checksum files in the root of
+ *  repository by prefix maven-metadata.xml (it can be done using storage.list), there will be
+ *  few checksum files like `maven-metadata.xml.md5`, `maven-metadata.xml.sha1`,
+ *  `maven-metadata.xml.sha256`, `maven-metadata.xml.sha512`. We need to update all these files
+ *  with checksums of `maven-metadata.xml` data using checksum file extension as digest algorithm.
+ *  If we found some unsupported algorithm, then delete checksum file. I'd start with
+ *  `MD5`, `SHA-256`, `SHA-1` and `SHA-512`. After this, enable testes in
+ *  MavenTest.
+ */
+public final class AstoMaven implements Maven {
+
+    /**
+     * Repository storage.
+     */
+    private final Storage storage;
+
+    /**
+     * Update metadata executor.
+     */
+    private final Executor exec;
+
+    /**
+     * Ctor.
+     * @param storage Maven repo storage
+     */
+    public AstoMaven(final Storage storage) {
+        this(storage, Executors.newSingleThreadExecutor());
+    }
+
+    /**
+     * Constructor.
+     * @param storage Storage used by this class.
+     * @param exec Executor
+     */
+    public AstoMaven(final Storage storage, final Executor exec) {
+        this.storage = storage;
+        this.exec = exec;
+    }
+
+    @Override
+    public CompletionStage<Void> update(final Key pkg) {
+        return this.storage.value(new Key.From(pkg, "maven-metadata.xml"))
+            .thenComposeAsync(
+                pub -> new Concatenation(pub).single().to(SingleInterop.get()), this.exec
+            )
+            .thenApplyAsync(buf -> new String(new Remaining(buf).bytes(), StandardCharsets.UTF_8))
+            .thenApply(XMLDocument::new)
+            .thenApply(doc -> new MavenMetadata(Directives.copyOf(doc.node())))
+            .thenCompose(
+                doc -> this.storage.list(pkg).thenApply(
+                    items -> items.stream()
+                        .map(
+                            item -> item.string()
+                                .replaceAll(String.format("%s/", pkg.string()), "")
+                                .split("/")[0]
+                        )
+                        .filter(item -> !item.startsWith("maven-metadata"))
+                        .collect(Collectors.toSet())
+                ).thenApply(doc::versions)
+            ).thenCompose(doc -> doc.save(this.storage, pkg));
+    }
+}

--- a/src/main/java/com/artipie/maven/http/UpdateMavenSlice.java
+++ b/src/main/java/com/artipie/maven/http/UpdateMavenSlice.java
@@ -33,6 +33,7 @@ import com.artipie.http.rq.RequestLineFrom;
 import com.artipie.http.rs.RsStatus;
 import com.artipie.http.rs.RsWithStatus;
 import com.artipie.http.slice.KeyFromPath;
+import com.artipie.maven.AstoMaven;
 import com.artipie.maven.Maven;
 import com.artipie.maven.repository.ValidUpload;
 import java.nio.ByteBuffer;
@@ -77,11 +78,12 @@ final class UpdateMavenSlice implements Slice {
     /**
      * Ctor.
      * @param storage Storage
+     * @param maven Maven repo
      * @param validator Upload validation
      */
-    UpdateMavenSlice(final Storage storage, final ValidUpload validator) {
+    UpdateMavenSlice(final Storage storage, final Maven maven, final ValidUpload validator) {
         this.storage = storage;
-        this.maven = new Maven(storage);
+        this.maven = maven;
         this.validator = validator;
     }
 
@@ -90,7 +92,7 @@ final class UpdateMavenSlice implements Slice {
      * @param storage Storage
      */
     UpdateMavenSlice(final Storage storage) {
-        this(storage, new ValidUpload.Dummy());
+        this(storage, new AstoMaven(storage), new ValidUpload.Dummy());
     }
 
     @Override

--- a/src/test/java/com/artipie/maven/AstoMavenITCase.java
+++ b/src/test/java/com/artipie/maven/AstoMavenITCase.java
@@ -57,13 +57,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
- * Test case for {@link Maven}.
+ * Test case for {@link AstoMaven}.
  *
  * @since 0.3
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
-public final class MavenITCase {
+public final class AstoMavenITCase {
 
     /**
      * Temporary directory with repository data.
@@ -96,17 +96,15 @@ public final class MavenITCase {
     @Test
     void generatesMetadata() throws Exception {
         final FileStorage storage = new FileStorage(this.repo);
-        new Maven(storage)
+        new AstoMaven(storage)
             .update(new Key.From("com", "artipie", "asto"))
             .toCompletableFuture()
             .get();
         MatcherAssert.assertThat(
             new XMLDocument(
-                new String(
-                    Files.readAllBytes(
-                        this.repo.resolve("com").resolve("artipie").resolve("asto")
-                            .resolve("maven-metadata.xml")
-                    ),
+                Files.readString(
+                    this.repo.resolve("com").resolve("artipie").resolve("asto")
+                        .resolve("maven-metadata.xml"),
                     StandardCharsets.UTF_8
                 )
             ),

--- a/src/test/java/com/artipie/maven/AstoMavenTest.java
+++ b/src/test/java/com/artipie/maven/AstoMavenTest.java
@@ -34,12 +34,12 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
- * Unit tests for {@link Maven} class.
+ * Unit tests for {@link AstoMaven} class.
  *
  * @since 0.4
  * @checkstyle MethodNameCheck (500 lines)
  */
-public class MavenTest {
+public class AstoMavenTest {
 
     /**
      * Com name.
@@ -66,19 +66,21 @@ public class MavenTest {
     public void generateValidMd5Checksum() throws Exception {
         final Storage storage = new InMemoryStorage();
         storage.save(
-            new Key.From(MavenTest.COM, MavenTest.ARTIPIE, MavenTest.MAVEN, "Md5Pack.jar"),
+            new Key.From(
+                AstoMavenTest.COM, AstoMavenTest.ARTIPIE, AstoMavenTest.MAVEN, "Md5Pack.jar"
+            ),
             new Content.From("md5-package-content".getBytes())
         ).toCompletableFuture().get();
-        new Maven(storage)
-            .update(new Key.From(MavenTest.COM, MavenTest.ARTIPIE, MavenTest.MAVEN))
+        new AstoMaven(storage)
+            .update(new Key.From(AstoMavenTest.COM, AstoMavenTest.ARTIPIE, AstoMavenTest.MAVEN))
             .toCompletableFuture()
             .get();
         MatcherAssert.assertThat(
             storage.exists(
                 new Key.From(
-                    MavenTest.COM,
-                    MavenTest.ARTIPIE,
-                    MavenTest.MAVEN,
+                    AstoMavenTest.COM,
+                    AstoMavenTest.ARTIPIE,
+                    AstoMavenTest.MAVEN,
                     "maven-metadata.xml.md5"
                 )
             ).toCompletableFuture().get(),
@@ -91,19 +93,21 @@ public class MavenTest {
     public void generateValidSha1Checksum() throws Exception {
         final InMemoryStorage storage = new InMemoryStorage();
         storage.save(
-            new Key.From(MavenTest.COM, MavenTest.ARTIPIE, MavenTest.MAVEN, "Sha1Pack.jar"),
+            new Key.From(
+                AstoMavenTest.COM, AstoMavenTest.ARTIPIE, AstoMavenTest.MAVEN, "Sha1Pack.jar"
+            ),
             new Content.From("sha1-package-content".getBytes())
         ).toCompletableFuture().get();
-        new Maven(storage)
+        new AstoMaven(storage)
             .update(
-                new Key.From(MavenTest.COM, MavenTest.ARTIPIE, MavenTest.MAVEN)
+                new Key.From(AstoMavenTest.COM, AstoMavenTest.ARTIPIE, AstoMavenTest.MAVEN)
             ).toCompletableFuture().get();
         MatcherAssert.assertThat(
             storage.exists(
                 new Key.From(
-                    MavenTest.COM,
-                    MavenTest.ARTIPIE,
-                    MavenTest.MAVEN,
+                    AstoMavenTest.COM,
+                    AstoMavenTest.ARTIPIE,
+                    AstoMavenTest.MAVEN,
                     "maven-metadata.xml.sha1"
                 )
             ).toCompletableFuture().get(),
@@ -116,19 +120,21 @@ public class MavenTest {
     public void generateValidSha256Checksum() throws Exception {
         final InMemoryStorage storage = new InMemoryStorage();
         storage.save(
-            new Key.From(MavenTest.COM, MavenTest.ARTIPIE, MavenTest.MAVEN, "Sha256Pack.jar"),
+            new Key.From(
+                AstoMavenTest.COM, AstoMavenTest.ARTIPIE, AstoMavenTest.MAVEN, "Sha256Pack.jar"
+            ),
             new Content.From("sha256-package-content".getBytes())
         ).toCompletableFuture().get();
-        new Maven(storage)
+        new AstoMaven(storage)
             .update(
-                new Key.From(MavenTest.COM, MavenTest.ARTIPIE, MavenTest.MAVEN)
+                new Key.From(AstoMavenTest.COM, AstoMavenTest.ARTIPIE, AstoMavenTest.MAVEN)
             ).toCompletableFuture().get();
         MatcherAssert.assertThat(
             storage.exists(
                 new Key.From(
-                    MavenTest.COM,
-                    MavenTest.ARTIPIE,
-                    MavenTest.MAVEN,
+                    AstoMavenTest.COM,
+                    AstoMavenTest.ARTIPIE,
+                    AstoMavenTest.MAVEN,
                     "maven-metadata.xml.sha256"
                 )
             ).toCompletableFuture().get(),
@@ -141,23 +147,25 @@ public class MavenTest {
     public void generateValidSha512Checksum() throws Exception {
         final InMemoryStorage storage = new InMemoryStorage();
         storage.save(
-            new Key.From(MavenTest.COM, MavenTest.ARTIPIE, MavenTest.MAVEN, "Sha512Pack.jar"),
+            new Key.From(
+                AstoMavenTest.COM, AstoMavenTest.ARTIPIE, AstoMavenTest.MAVEN, "Sha512Pack.jar"
+            ),
             new Content.From("sha512-package-content".getBytes())
         )
             .toCompletableFuture()
             .get();
-        new Maven(storage)
+        new AstoMaven(storage)
             .update(
-                new Key.From(MavenTest.COM, MavenTest.ARTIPIE, MavenTest.MAVEN)
+                new Key.From(AstoMavenTest.COM, AstoMavenTest.ARTIPIE, AstoMavenTest.MAVEN)
             )
             .toCompletableFuture()
             .get();
         MatcherAssert.assertThat(
             storage.exists(
                 new Key.From(
-                    MavenTest.COM,
-                    MavenTest.ARTIPIE,
-                    MavenTest.MAVEN,
+                    AstoMavenTest.COM,
+                    AstoMavenTest.ARTIPIE,
+                    AstoMavenTest.MAVEN,
                     "maven-metadata.xml.sha512"
                 )
             ).toCompletableFuture().get(),
@@ -171,21 +179,22 @@ public class MavenTest {
         final InMemoryStorage storage = new InMemoryStorage();
         storage.save(
             new Key.From(
-                MavenTest.COM, MavenTest.ARTIPIE, MavenTest.MAVEN, MavenTest.UNSUPPORTED
+                AstoMavenTest.COM, AstoMavenTest.ARTIPIE,
+                AstoMavenTest.MAVEN, AstoMavenTest.UNSUPPORTED
             ),
             new Content.From("anything".getBytes())
         ).toCompletableFuture().get();
-        new Maven(storage)
-            .update(new Key.From(MavenTest.COM, MavenTest.ARTIPIE, MavenTest.MAVEN))
+        new AstoMaven(storage)
+            .update(new Key.From(AstoMavenTest.COM, AstoMavenTest.ARTIPIE, AstoMavenTest.MAVEN))
             .toCompletableFuture()
             .get();
         MatcherAssert.assertThat(
             storage.exists(
                 new Key.From(
-                    MavenTest.COM,
-                    MavenTest.ARTIPIE,
-                    MavenTest.MAVEN,
-                    MavenTest.UNSUPPORTED
+                    AstoMavenTest.COM,
+                    AstoMavenTest.ARTIPIE,
+                    AstoMavenTest.MAVEN,
+                    AstoMavenTest.UNSUPPORTED
                 )
             ).toCompletableFuture().get(),
             new IsEqual<>(false)


### PR DESCRIPTION
For #124 I've extracted interface from `Maven`, renamed `Maven` to `AstoMaven` and extended `UpdateMavenSliceTest` to verify that `Maven#update` is called.