### PR TITLE
#113 - upload files to temp location

### DIFF
--- a/src/main/java/com/artipie/maven/http/UpdateMavenSlice.java
+++ b/src/main/java/com/artipie/maven/http/UpdateMavenSlice.java
@@ -24,8 +24,10 @@
 package com.artipie.maven.http;
 
 import com.artipie.asto.Content;
+import com.artipie.asto.Copy;
 import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
+import com.artipie.asto.SubStorage;
 import com.artipie.http.Response;
 import com.artipie.http.Slice;
 import com.artipie.http.async.AsyncResponse;
@@ -37,11 +39,14 @@ import com.artipie.maven.AstoMaven;
 import com.artipie.maven.Maven;
 import com.artipie.maven.repository.ValidUpload;
 import java.nio.ByteBuffer;
+import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.cactoos.list.ListOf;
 import org.reactivestreams.Publisher;
 
 /**
@@ -53,6 +58,11 @@ import org.reactivestreams.Publisher;
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 final class UpdateMavenSlice implements Slice {
+
+    /**
+     * Temp storage key.
+     */
+    static final Key TEMP = new Key.From(DigestUtils.md5Hex("upload".getBytes()));
 
     /**
      * Metadata pattern.
@@ -101,32 +111,41 @@ final class UpdateMavenSlice implements Slice {
         final RequestLineFrom reqline = new RequestLineFrom(line);
         final String path = reqline.uri().getPath();
         final Matcher matcher = PTN_META.matcher(path);
+        final Storage temp = new SubStorage(UpdateMavenSlice.TEMP, this.storage);
         return new AsyncResponse(
-            this.storage.save(
+            temp.save(
                 new KeyFromPath(new RequestLineFrom(line).uri().getPath()), new Content.From(body)
             ).thenCompose(
                 ignored -> {
                     final CompletionStage<Response> res;
                     if (matcher.matches()) {
                         final Key location = new Key.From(matcher.group("pkg"));
-                        res = this.validator.validate(location).thenCompose(
-                            valid -> {
-                                final CompletionStage<Response> upd;
-                                if (valid) {
-                                    upd = this.maven.update(location)
-                                        .thenApply(nothing -> new RsWithStatus(RsStatus.CREATED));
-                                } else {
-                                    upd = this.storage.list(location).thenCompose(
-                                        items -> CompletableFuture.allOf(
-                                            items.stream().map(this.storage::delete)
-                                                .toArray(CompletableFuture[]::new)
-                                        )
-                                    ).thenApply(
-                                        nothing -> new RsWithStatus(RsStatus.BAD_REQUEST)
-                                    );
+                        res = this.validator.validate(new Key.From(UpdateMavenSlice.TEMP, location))
+                            .thenCompose(
+                                valid -> {
+                                    final CompletionStage<Response> upd;
+                                    if (valid) {
+                                        upd = temp.list(location).thenCompose(
+                                            list -> new Copy(temp, new ListOf<>(list))
+                                                .copy(this.storage).thenCompose(
+                                                    nothing -> CompletableFuture.allOf(
+                                                        this.maven.update(location)
+                                                            .toCompletableFuture(),
+                                                        UpdateMavenSlice.remove(temp, list)
+                                                    ).thenApply(
+                                                        any -> new RsWithStatus(RsStatus.CREATED)
+                                                    )
+                                                )
+                                        );
+                                    } else {
+                                        upd = temp.list(location).thenCompose(
+                                            items -> UpdateMavenSlice.remove(temp, items)
+                                        ).thenApply(
+                                            nothing -> new RsWithStatus(RsStatus.BAD_REQUEST)
+                                        );
+                                    }
+                                    return upd;
                                 }
-                                return upd;
-                            }
                         );
                     } else {
                         res = CompletableFuture.completedFuture(new RsWithStatus(RsStatus.CREATED));
@@ -134,6 +153,19 @@ final class UpdateMavenSlice implements Slice {
                     return res;
                 }
             )
+        );
+    }
+
+    /**
+     * Delete items from storage.
+     * @param asto Storage
+     * @param items Keys to remove
+     * @return Completable remove operation
+     */
+    private static CompletableFuture<Void> remove(final Storage asto, final Collection<Key> items) {
+        return CompletableFuture.allOf(
+            items.stream().map(asto::delete)
+                .toArray(CompletableFuture[]::new)
         );
     }
 }

--- a/src/main/java/com/artipie/maven/http/UpdateMavenSlice.java
+++ b/src/main/java/com/artipie/maven/http/UpdateMavenSlice.java
@@ -45,7 +45,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.apache.commons.codec.digest.DigestUtils;
 import org.cactoos.list.ListOf;
 import org.reactivestreams.Publisher;
 
@@ -62,7 +61,7 @@ final class UpdateMavenSlice implements Slice {
     /**
      * Temp storage key.
      */
-    static final Key TEMP = new Key.From(DigestUtils.md5Hex("upload".getBytes()));
+    static final Key TEMP = new Key.From(".upload");
 
     /**
      * Metadata pattern.

--- a/src/test/java/com/artipie/maven/http/UpdateMavenSliceTest.java
+++ b/src/test/java/com/artipie/maven/http/UpdateMavenSliceTest.java
@@ -23,18 +23,18 @@
  */
 package com.artipie.maven.http;
 
+import com.artipie.asto.Content;
 import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
 import com.artipie.asto.ext.PublisherAs;
 import com.artipie.asto.memory.InMemoryStorage;
+import com.artipie.http.Headers;
 import com.artipie.http.hm.RsHasStatus;
+import com.artipie.http.hm.SliceHasResponse;
 import com.artipie.http.rq.RequestLine;
 import com.artipie.http.rs.RsStatus;
 import com.artipie.maven.Maven;
 import com.artipie.maven.repository.ValidUpload;
-import io.reactivex.Flowable;
-import java.nio.ByteBuffer;
-import java.util.Collections;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.collection.IsEmptyCollection;
 import org.hamcrest.collection.IsEmptyIterable;
@@ -56,12 +56,12 @@ class UpdateMavenSliceTest {
         final String location = "org/example/artifact/0.1/artifact-1.0.jar";
         MatcherAssert.assertThat(
             "Returns CREATED status",
-            new UpdateMavenSlice(storage).response(
-                new RequestLine("PUT", String.format("/%s", location)).toString(),
-                Collections.emptyList(),
-                Flowable.fromArray(ByteBuffer.wrap(body))
-            ),
-            new RsHasStatus(RsStatus.CREATED)
+            new UpdateMavenSlice(storage),
+            new SliceHasResponse(
+                new RsHasStatus(RsStatus.CREATED),
+                new RequestLine("PUT", String.format("/%s", location)),
+                Headers.EMPTY, new Content.From(body)
+            )
         );
         MatcherAssert.assertThat(
             "Puts file to storage",
@@ -83,21 +83,21 @@ class UpdateMavenSliceTest {
         );
         MatcherAssert.assertThat(
             "Returns CREATED status for jar",
-            update.response(
-                new RequestLine("PUT", String.format("/%s", jlocation)).toString(),
-                Collections.emptyList(),
-                Flowable.fromArray(ByteBuffer.wrap(jar))
-            ),
-            new RsHasStatus(RsStatus.CREATED)
+            update,
+            new SliceHasResponse(
+                new RsHasStatus(RsStatus.CREATED),
+                new RequestLine("PUT", String.format("/%s", jlocation)),
+                Headers.EMPTY, new Content.From(jar)
+            )
         );
         MatcherAssert.assertThat(
             "Returns CREATED status for metadata",
-            update.response(
-                new RequestLine("PUT", String.format("/%s", mlocation)).toString(),
-                Collections.emptyList(),
-                Flowable.fromArray(ByteBuffer.wrap(meta))
-            ),
-            new RsHasStatus(RsStatus.CREATED)
+            update,
+            new SliceHasResponse(
+                new RsHasStatus(RsStatus.CREATED),
+                new RequestLine("PUT", String.format("/%s", mlocation)),
+                Headers.EMPTY, new Content.From(meta)
+            )
         );
         MatcherAssert.assertThat(
             "Puts jar to main storage",
@@ -125,12 +125,12 @@ class UpdateMavenSliceTest {
         final String location = "org/example/artifact/0.1/maven-metadata.xml";
         MatcherAssert.assertThat(
             "Returns BAD_REQUEST status",
-            new UpdateMavenSlice(storage, new Maven.Fake(), new ValidUpload.Dummy(false)).response(
-                new RequestLine("PUT", String.format("/%s", location)).toString(),
-                Collections.emptyList(),
-                Flowable.fromArray(ByteBuffer.wrap(body))
-            ),
-            new RsHasStatus(RsStatus.BAD_REQUEST)
+            new UpdateMavenSlice(storage, new Maven.Fake(), new ValidUpload.Dummy(false)),
+            new SliceHasResponse(
+                new RsHasStatus(RsStatus.BAD_REQUEST),
+                new RequestLine("PUT", String.format("/%s", location)),
+                Headers.EMPTY, new Content.From(body)
+            )
         );
         MatcherAssert.assertThat(
             "Storage is empty",
@@ -147,12 +147,12 @@ class UpdateMavenSliceTest {
         final Maven.Fake maven = new Maven.Fake();
         MatcherAssert.assertThat(
             "Returns CREATED status",
-            new UpdateMavenSlice(storage, maven, new ValidUpload.Dummy(true)).response(
-                new RequestLine("PUT", String.format("/%s", location)).toString(),
-                Collections.emptyList(),
-                Flowable.fromArray(ByteBuffer.wrap(body))
-            ),
-            new RsHasStatus(RsStatus.CREATED)
+            new UpdateMavenSlice(storage, maven, new ValidUpload.Dummy(true)),
+            new SliceHasResponse(
+                new RsHasStatus(RsStatus.CREATED),
+                new RequestLine("PUT", String.format("/%s", location)),
+                Headers.EMPTY, new Content.From(body)
+            )
         );
         MatcherAssert.assertThat(
             "Updates maven repo",


### PR DESCRIPTION
Part of #113. 
`UpdateMavenSlice` now uploads files to temp location and then after `maven-metadata.xml` is received and upload is validated copies them to permanent location.