### PR TITLE
#113 - Maven upload validation enabled

### DIFF
--- a/src/main/java/com/artipie/maven/Maven.java
+++ b/src/main/java/com/artipie/maven/Maven.java
@@ -35,10 +35,11 @@ public interface Maven {
 
     /**
      * Updates the metadata of a maven package.
-     * @param pkg Maven package key
+     * @param upload Uploading artifact location
+     * @param artifact Artifact location
      * @return Completion stage
      */
-    CompletionStage<Void> update(Key pkg);
+    CompletionStage<Void> update(Key upload, Key artifact);
 
     /**
      * Fake {@link Maven} implementation.
@@ -52,7 +53,7 @@ public interface Maven {
         private boolean updated;
 
         @Override
-        public CompletionStage<Void> update(final Key pkg) {
+        public CompletionStage<Void> update(final Key upload, final Key artifact) {
             this.updated = true;
             return CompletableFuture.allOf();
         }

--- a/src/main/java/com/artipie/maven/ValidUpload.java
+++ b/src/main/java/com/artipie/maven/ValidUpload.java
@@ -38,8 +38,8 @@ public interface ValidUpload {
      * - validate upload checksums;
      * - validate metadata: check metadata group and id are the same as in
      * repository metadata, metadata versions are correct.
-     * @param upload Upload artifact files location
-     * @param artifact Artifact files location
+     * @param upload Uploading artifact location
+     * @param artifact Artifact location
      * @return Completable validation action: true if uploaded maven-metadata.xml is valid,
      *  false otherwise
      */

--- a/src/main/java/com/artipie/maven/metadata/ArtifactsMetadata.java
+++ b/src/main/java/com/artipie/maven/metadata/ArtifactsMetadata.java
@@ -61,6 +61,7 @@ public final class ArtifactsMetadata {
      * @param location Package location
      * @return Version as completed stage
      */
+    @SuppressWarnings("PMD.ConfusingTernary")
     public CompletionStage<String> release(final Key location) {
         return this.storage.value(new Key.From(location, ArtifactsMetadata.MAVEN_METADATA))
             .thenCompose(
@@ -71,9 +72,9 @@ public final class ArtifactsMetadata {
                         final String latest = "//latest/text()";
                         final String release = "//release/text()";
                         final String res;
-                        if (xml.xpath(release).size() > 0) {
+                        if (!xml.xpath(release).isEmpty()) {
                             res = xml.xpath(release).get(0);
-                        } else if (xml.xpath(latest).size() > 0) {
+                        } else if (!xml.xpath(latest).isEmpty()) {
                             res = xml.xpath(latest).get(0);
                         } else {
                             throw new IllegalArgumentException(

--- a/src/test/java/com/artipie/maven/AstoMavenITCase.java
+++ b/src/test/java/com/artipie/maven/AstoMavenITCase.java
@@ -78,12 +78,14 @@ public final class AstoMavenITCase {
     void setUp() {
         final Storage resources = new FileStorage(new TestResource("com/artipie/asto").asPath());
         this.repository = new FileStorage(this.repo);
+        final String latest = "0.20.2";
+        final String meta = "maven-metadata.xml";
         resources.list(Key.ROOT).thenCompose(
             list -> CompletableFuture.allOf(list.stream()
                 .filter(
                     item -> !item.string().contains("1.0-SNAPSHOT")
-                        && !item.string().contains("0.20.2")
-                        && !item.string().contains("maven-metadata.xml")
+                        && !item.string().contains(latest)
+                        && !item.string().contains(meta)
                 )
                 .map(
                     item -> resources.value(item).thenCompose(
@@ -99,8 +101,8 @@ public final class AstoMavenITCase {
             list -> CompletableFuture.allOf(
                 list.stream()
                 .filter(
-                    item -> item.string().contains("0.20.2")
-                    || item.string().contains("maven-metadata.xml")
+                    item -> item.string().contains(latest)
+                    || item.string().contains(meta)
                 )
                 .map(
                     item -> resources.value(item).thenCompose(

--- a/src/test/java/com/artipie/maven/AstoMavenITCase.java
+++ b/src/test/java/com/artipie/maven/AstoMavenITCase.java
@@ -82,6 +82,7 @@ public final class AstoMavenITCase {
             list -> CompletableFuture.allOf(list.stream()
                 .filter(
                     item -> !item.string().contains("1.0-SNAPSHOT")
+                        && !item.string().contains("0.20.2")
                         && !item.string().contains("maven-metadata.xml")
                 )
                 .map(
@@ -98,7 +99,7 @@ public final class AstoMavenITCase {
             list -> CompletableFuture.allOf(
                 list.stream()
                 .filter(
-                    item -> item.string().contains("1.0-SNAPSHOT")
+                    item -> item.string().contains("0.20.2")
                     || item.string().contains("maven-metadata.xml")
                 )
                 .map(
@@ -130,15 +131,14 @@ public final class AstoMavenITCase {
                     // @checkstyle LineLengthCheck (20 lines)
                     XhtmlMatchers.hasXPath("/metadata/groupId[text() = 'com.artipie']"),
                     XhtmlMatchers.hasXPath("/metadata/artifactId[text() = 'asto']"),
-                    XhtmlMatchers.hasXPath("/metadata/versioning/latest[text() = '1.0-SNAPSHOT']"),
+                    XhtmlMatchers.hasXPath("/metadata/versioning/latest[text() = '0.20.2']"),
                     XhtmlMatchers.hasXPath("/metadata/versioning/release[text() = '0.20.2']"),
-                    XhtmlMatchers.hasXPath("/metadata/versioning/versions/version[text() = '0.18']"),
                     XhtmlMatchers.hasXPath("/metadata/versioning/versions/version[text() = '0.15']"),
                     XhtmlMatchers.hasXPath("/metadata/versioning/versions/version[text() = '0.11.1']"),
                     XhtmlMatchers.hasXPath("/metadata/versioning/versions/version[text() = '0.20.1']"),
                     XhtmlMatchers.hasXPath("/metadata/versioning/versions/version[text() = '0.20.2']"),
-                    XhtmlMatchers.hasXPath("/metadata/versioning/versions/version[text() = '1.0-SNAPSHOT']"),
                     XhtmlMatchers.hasXPath("/metadata/versioning/versions/version[text() = '0.18']"),
+                    XhtmlMatchers.hasXPath("metadata/versioning/versions[count(//version) = 5]"),
                     XhtmlMatchers.hasXPath("/metadata/versioning/lastUpdated")
                 )
             )

--- a/src/test/java/com/artipie/maven/AstoMavenTest.java
+++ b/src/test/java/com/artipie/maven/AstoMavenTest.java
@@ -58,6 +58,11 @@ public class AstoMavenTest {
     public static final String MAVEN = "maven";
 
     /**
+     * Maven name.
+     */
+    public static final String META = ".update/com/artipie/maven/maven-metadata.xml";
+
+    /**
      * Unsupported algorithm checksum file name.
      */
     public static final String UNSUPPORTED = "maven-metadata.xml.unsupported";
@@ -73,9 +78,10 @@ public class AstoMavenTest {
             new Content.From("md5-package-content".getBytes())
         ).toCompletableFuture().get();
         new AstoMaven(storage)
-            .update(new Key.From(AstoMavenTest.COM, AstoMavenTest.ARTIPIE, AstoMavenTest.MAVEN))
-            .toCompletableFuture()
-            .get();
+            .update(
+                new Key.From(AstoMavenTest.COM, AstoMavenTest.ARTIPIE, AstoMavenTest.MAVEN),
+                new Key.From(AstoMavenTest.META)
+            ).toCompletableFuture().get();
         MatcherAssert.assertThat(
             storage.exists(
                 new Key.From(
@@ -101,7 +107,8 @@ public class AstoMavenTest {
         ).toCompletableFuture().get();
         new AstoMaven(storage)
             .update(
-                new Key.From(AstoMavenTest.COM, AstoMavenTest.ARTIPIE, AstoMavenTest.MAVEN)
+                new Key.From(AstoMavenTest.COM, AstoMavenTest.ARTIPIE, AstoMavenTest.MAVEN),
+                new Key.From(AstoMavenTest.META)
             ).toCompletableFuture().get();
         MatcherAssert.assertThat(
             storage.exists(
@@ -128,7 +135,8 @@ public class AstoMavenTest {
         ).toCompletableFuture().get();
         new AstoMaven(storage)
             .update(
-                new Key.From(AstoMavenTest.COM, AstoMavenTest.ARTIPIE, AstoMavenTest.MAVEN)
+                new Key.From(AstoMavenTest.COM, AstoMavenTest.ARTIPIE, AstoMavenTest.MAVEN),
+                new Key.From(AstoMavenTest.META)
             ).toCompletableFuture().get();
         MatcherAssert.assertThat(
             storage.exists(
@@ -157,7 +165,8 @@ public class AstoMavenTest {
             .get();
         new AstoMaven(storage)
             .update(
-                new Key.From(AstoMavenTest.COM, AstoMavenTest.ARTIPIE, AstoMavenTest.MAVEN)
+                new Key.From(AstoMavenTest.COM, AstoMavenTest.ARTIPIE, AstoMavenTest.MAVEN),
+                new Key.From(AstoMavenTest.META)
             )
             .toCompletableFuture()
             .get();
@@ -186,8 +195,10 @@ public class AstoMavenTest {
             new Content.From("anything".getBytes())
         ).toCompletableFuture().get();
         new AstoMaven(storage)
-            .update(new Key.From(AstoMavenTest.COM, AstoMavenTest.ARTIPIE, AstoMavenTest.MAVEN))
-            .toCompletableFuture()
+            .update(
+                new Key.From(AstoMavenTest.COM, AstoMavenTest.ARTIPIE, AstoMavenTest.MAVEN),
+                new Key.From(AstoMavenTest.META)
+            ).toCompletableFuture()
             .get();
         MatcherAssert.assertThat(
             storage.exists(

--- a/src/test/java/com/artipie/maven/metadata/ArtifactsMetadataTest.java
+++ b/src/test/java/com/artipie/maven/metadata/ArtifactsMetadataTest.java
@@ -60,7 +60,7 @@ class ArtifactsMetadataTest {
     @Test
     void readsVersion() {
         MatcherAssert.assertThat(
-            new ArtifactsMetadata(this.storage).latest(this.key).toCompletableFuture().join(),
+            new ArtifactsMetadata(this.storage).release(this.key).toCompletableFuture().join(),
             new IsEqual<>("1.0")
         );
     }

--- a/src/test/resources-binary/com/artipie/asto/maven-metadata.xml
+++ b/src/test/resources-binary/com/artipie/asto/maven-metadata.xml
@@ -26,7 +26,7 @@ SOFTWARE.
   <groupId>com.artipie</groupId>
   <artifactId>asto</artifactId>
   <versioning>
-    <latest>0.20.2</latest>
+    <latest>1.0-SNAPSHOT</latest>
     <release>0.20.2</release>
     <versions>
       <version>0.3.0</version>


### PR DESCRIPTION
Closes #113, now all files are uploaded to the temp location, validated, metadata generated and copied to permanent location. Changes:
- `AstoMaven` generates `maven-metadata.xml` to temp location, uploaded version is read from uploaded `maven-metadata.xml`
- `ArtifactsMetadata` reads `release` version from `maven-metadata.xml` as uploaded `maven-metadata.xml` not necessarily contains `latest` tag, xml for the new artifact looks like this
```
<?xml version="1.0" encoding="UTF-8"?>
<metadata>
  <groupId>org.apache.maven.resolver</groupId>
  <artifactId>maven-resolver-util</artifactId>
  <versioning>
    <release>1.3.3</release>
    <versions>
      <version>1.3.3</version>
    </versions>
    <lastUpdated>20200817054301</lastUpdated>
  </versioning>
</metadata>
``` 
- `AstoValidUpload` works properly with new artifact (when first version is uploaded)
- `AstoMavenITCase` corrected with usage `TestResource` from asto
- created #144 to handle snapshot properly