### PR TITLE
Extended `ValidUpload` with `ready()` method

### DIFF
--- a/src/main/java/com/artipie/maven/ValidUpload.java
+++ b/src/main/java/com/artipie/maven/ValidUpload.java
@@ -47,7 +47,7 @@ public interface ValidUpload {
 
     /**
      * Is the upload ready to be added to repository? The upload is considered to be ready if
-     * at least an artifact, maven-metadata.xml and two checksums are present in the location.
+     * at an artifact (any, nondeterministic) and maven-metadata.xml have the same set of checksums.
      * @param location Upload location to check
      * @return Completable action with the result
      */

--- a/src/main/java/com/artipie/maven/ValidUpload.java
+++ b/src/main/java/com/artipie/maven/ValidUpload.java
@@ -46,6 +46,14 @@ public interface ValidUpload {
     CompletionStage<Boolean> validate(Key upload, Key artifact);
 
     /**
+     * Is the upload ready to be added to repository? The upload is considered to be ready if
+     * at least an artifact, maven-metadata.xml and two checksums are present in the location.
+     * @param location Upload location to check
+     * @return Completable action with the result
+     */
+    CompletionStage<Boolean> ready(Key location);
+
+    /**
      * Dummy {@link ValidUpload} implementation.
      * @since 0.5
      */
@@ -75,6 +83,12 @@ public interface ValidUpload {
         public CompletionStage<Boolean> validate(final Key upload, final Key artifact) {
             return CompletableFuture.completedFuture(this.res);
         }
+
+        @Override
+        public CompletionStage<Boolean> ready(final Key location) {
+            return CompletableFuture.completedFuture(true);
+        }
+
     }
 
 }

--- a/src/test/java/com/artipie/maven/asto/AstoValidUploadTest.java
+++ b/src/test/java/com/artipie/maven/asto/AstoValidUploadTest.java
@@ -29,10 +29,13 @@ import com.artipie.asto.blocking.BlockingStorage;
 import com.artipie.asto.memory.InMemoryStorage;
 import com.artipie.asto.test.TestResource;
 import com.artipie.maven.MetadataXml;
+import java.util.Arrays;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 /**
  * Test for {@link AstoValidUpload}.
@@ -131,6 +134,32 @@ public final class AstoValidUploadTest {
         MatcherAssert.assertThat(
             this.validupload.validate(upload, artifact).toCompletableFuture().join(),
             new IsEqual<>(false)
+        );
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "pom;jar,xml;xml.sha1;xml.md5,true",
+        "war,xml;xml.sha1;xml.md5;xml.sha256,true",
+        "pom;rar,xml;xml.sha1;xml.sha256,true",
+        "'',xml;xml.sha1;xml.md5,false",
+        "jar,xml;xml.sha1,false"
+    })
+    void returnsTrueWhenReady(final String artifacts, final String meta, final boolean res) {
+        final Key location = new Key.From(".upload/com/artipie/example/0.2");
+        Arrays.stream(artifacts.split(";")).forEach(
+            item -> this.bsto.save(
+                new Key.From(location, String.format("example-0.2.%s", item)), new byte[]{}
+            )
+        );
+        Arrays.stream(meta.split(";")).forEach(
+            item -> this.bsto.save(
+                new Key.From(location, String.format("maven-metadata.%s", item)), new byte[]{}
+            )
+        );
+        MatcherAssert.assertThat(
+            this.validupload.ready(location).toCompletableFuture().join(),
+            new IsEqual<>(res)
         );
     }
 

--- a/src/test/java/com/artipie/maven/asto/AstoValidUploadTest.java
+++ b/src/test/java/com/artipie/maven/asto/AstoValidUploadTest.java
@@ -139,11 +139,12 @@ public final class AstoValidUploadTest {
 
     @ParameterizedTest
     @CsvSource({
-        "pom;jar,xml;xml.sha1;xml.md5,true",
-        "war,xml;xml.sha1;xml.md5;xml.sha256,true",
-        "pom;rar,xml;xml.sha1;xml.sha256,true",
+        "pom;pom.sha1;jar;jar.sha1,xml;xml.sha1,true",
+        "war;war.md5;war.sha1,xml;xml.sha1;xml.md5,true",
+        "pom;rar,xml;xml.sha1;xml.sha256,false",
         "'',xml;xml.sha1;xml.md5,false",
-        "jar,xml;xml.sha1,false"
+        "jar;jar.sha256,xml;xml.sha1,false",
+        "war;war.sha256,xml,false"
     })
     void returnsTrueWhenReady(final String artifacts, final String meta, final boolean res) {
         final Key location = new Key.From(".upload/com/artipie/example/0.2");


### PR DESCRIPTION
Part of #227 
Extended `ValidUpload` with `ready()` method to check whether the upload is ready to be added to the repository