### PR TITLE
Added new `Maven` implementation

### DIFF
--- a/src/main/java/com/artipie/maven/asto/AstoMavenWithMove.java
+++ b/src/main/java/com/artipie/maven/asto/AstoMavenWithMove.java
@@ -1,0 +1,143 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.maven.asto;
+
+import com.artipie.asto.Copy;
+import com.artipie.asto.Key;
+import com.artipie.asto.Storage;
+import com.artipie.asto.SubStorage;
+import com.artipie.asto.ext.PublisherAs;
+import com.artipie.maven.Maven;
+import com.artipie.maven.metadata.ArtifactsMetadata;
+import com.artipie.maven.metadata.MavenMetadata;
+import com.jcabi.xml.XMLDocument;
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Collectors;
+import org.xembly.Directives;
+
+/**
+ * Maven front for artipie maven adaptor.
+ *
+ * @since 0.2
+ */
+public final class AstoMavenWithMove implements Maven {
+
+    /**
+     * Maven metadata xml name.
+     */
+    private static final String MAVEN_META = "maven-metadata.xml";
+
+    /**
+     * Repository storage.
+     */
+    private final Storage storage;
+
+    /**
+     * Constructor.
+     * @param storage Storage used by this class.
+     */
+    public AstoMavenWithMove(final Storage storage) {
+        this.storage = storage;
+    }
+
+    @Override
+    public CompletionStage<Void> update(final Key upload, final Key artifact) {
+        return this.storage.exclusively(
+            artifact,
+            target -> this.storage.value(new Key.From(upload, AstoMavenWithMove.MAVEN_META))
+                .thenCompose(
+                    pub -> new PublisherAs(pub).asciiString()
+                )
+                .thenApply(XMLDocument::new)
+                .thenApply(doc -> new MavenMetadata(Directives.copyOf(doc.node())))
+                .thenCompose(
+                    doc -> target.list(artifact).thenApply(
+                        items -> items.stream()
+                            .map(
+                                item -> item.string()
+                                    .replaceAll(String.format("%s/", artifact.string()), "")
+                                    .split("/")[0]
+                            )
+                            .filter(item -> !item.startsWith("maven-metadata"))
+                            .collect(Collectors.toSet())
+                    ).thenCompose(
+                        versions -> new ArtifactsMetadata(this.storage).maxVersion(upload)
+                            .thenApply(
+                                latest -> {
+                                    versions.add(latest);
+                                    return doc.versions(versions);
+                                }
+                        )
+                    )
+                ).thenCompose(doc -> doc.save(this.storage, upload))
+                .thenCompose(meta -> new RepositoryChecksums(this.storage).generate(meta))
+                .thenCompose(nothing -> this.moveToTheRepository(upload, target, artifact))
+                .thenCompose(nothing -> this.storage.list(upload).thenCompose(this::remove))
+            );
+    }
+
+    /**
+     * Moves artifacts from temp location to repository.
+     * @param upload Upload temp location
+     * @param target Repository
+     * @param artifact Artifact repository location
+     * @return Completion action
+     */
+    private CompletableFuture<Void> moveToTheRepository(
+        final Key upload, final Storage target, final Key artifact
+    ) {
+        final Storage sub = new SubStorage(upload, this.storage);
+        final Storage subversion = new SubStorage(upload.parent().get(), this.storage);
+        return sub.list(Key.ROOT).thenCompose(
+            list -> new Copy(
+                sub,
+                list.stream().filter(key -> key.string().contains(AstoMavenWithMove.MAVEN_META))
+                    .collect(Collectors.toList())
+            ).copy(new SubStorage(artifact, target))
+        ).thenCompose(
+            nothing -> subversion.list(Key.ROOT).thenCompose(
+                list -> new Copy(
+                    subversion,
+                    list.stream()
+                        .filter(key -> !key.string().contains(AstoMavenWithMove.MAVEN_META))
+                        .collect(Collectors.toList())
+                ).copy(new SubStorage(artifact, target))
+            )
+        );
+    }
+
+    /**
+     * Delete items from storage.
+     * @param items Keys to remove
+     * @return Completable remove operation
+     */
+    private CompletableFuture<Void> remove(final Collection<Key> items) {
+        return CompletableFuture.allOf(
+            items.stream().map(this.storage::delete)
+                .toArray(CompletableFuture[]::new)
+        );
+    }
+}

--- a/src/test/java/com/artipie/maven/asto/AstoMavenWithMoveTest.java
+++ b/src/test/java/com/artipie/maven/asto/AstoMavenWithMoveTest.java
@@ -1,0 +1,281 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.maven.asto;
+
+import com.artipie.asto.Key;
+import com.artipie.asto.Storage;
+import com.artipie.asto.blocking.BlockingStorage;
+import com.artipie.asto.ext.KeyLastPart;
+import com.artipie.asto.ext.PublisherAs;
+import com.artipie.asto.fs.FileStorage;
+import com.artipie.asto.memory.InMemoryStorage;
+import com.artipie.asto.test.TestResource;
+import com.artipie.maven.MetadataXml;
+import com.jcabi.matchers.XhtmlMatchers;
+import com.jcabi.xml.XML;
+import com.jcabi.xml.XMLDocument;
+import java.nio.charset.StandardCharsets;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.cactoos.list.ListOf;
+import org.cactoos.scalar.Unchecked;
+import org.hamcrest.Matcher;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.hamcrest.core.AllOf;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test for {@link AstoMavenWithMove}.
+ * @since 0.8
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ * @checkstyle MagicNumberCheck (500 lines)
+ */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+class AstoMavenWithMoveTest {
+
+    /**
+     * Logger upload key.
+     */
+    private static final Key LGR_UPLOAD = new Key.From(".update/com/test/logger");
+
+    /**
+     * Logger package key.
+     */
+    private static final Key LGR = new Key.From("com/test/logger");
+
+    /**
+     * Asto artifact key.
+     */
+    private static final Key.From ASTO = new Key.From("com/artipie/asto");
+
+    /**
+     * Asto upload key.
+     */
+    private static final Key.From ASTO_UPLOAD = new Key.From(".upload/com/artipie/asto");
+
+    /**
+     * Test storage.
+     */
+    private Storage storage;
+
+    @BeforeEach
+    void init() {
+        this.storage = new InMemoryStorage();
+    }
+
+    @Test
+    void generatesMetadata() {
+        final String latest = "0.20.2";
+        this.addFilesToStorage(
+            item -> !item.contains("1.0-SNAPSHOT") && !item.contains(latest),
+            AstoMavenWithMoveTest.ASTO
+        );
+        this.addFilesToStorage(
+            item -> item.contains(latest),
+            AstoMavenWithMoveTest.ASTO_UPLOAD
+        );
+        this.metadataAndVersions(latest);
+        new AstoMavenWithMove(this.storage).update(
+            new Key.From(AstoMavenWithMoveTest.ASTO_UPLOAD, latest), AstoMavenWithMoveTest.ASTO
+        ).toCompletableFuture().join();
+        MatcherAssert.assertThat(
+            "Maven metadata xml is not correct",
+            new XMLDocument(
+                this.storage.value(new Key.From(AstoMavenWithMoveTest.ASTO, "maven-metadata.xml"))
+                    .thenCompose(content -> new PublisherAs(content).string(StandardCharsets.UTF_8))
+                    .join()
+            ),
+            new AllOf<>(
+                new ListOf<Matcher<? super XML>>(
+                    // @checkstyle LineLengthCheck (20 lines)
+                    XhtmlMatchers.hasXPath("/metadata/groupId[text() = 'com.artipie']"),
+                    XhtmlMatchers.hasXPath("/metadata/artifactId[text() = 'asto']"),
+                    XhtmlMatchers.hasXPath("/metadata/versioning/latest[text() = '0.20.2']"),
+                    XhtmlMatchers.hasXPath("/metadata/versioning/release[text() = '0.20.2']"),
+                    XhtmlMatchers.hasXPath("/metadata/versioning/versions/version[text() = '0.15']"),
+                    XhtmlMatchers.hasXPath("/metadata/versioning/versions/version[text() = '0.11.1']"),
+                    XhtmlMatchers.hasXPath("/metadata/versioning/versions/version[text() = '0.20.1']"),
+                    XhtmlMatchers.hasXPath("/metadata/versioning/versions/version[text() = '0.20.2']"),
+                    XhtmlMatchers.hasXPath("/metadata/versioning/versions/version[text() = '0.18']"),
+                    XhtmlMatchers.hasXPath("metadata/versioning/versions[count(//version) = 5]"),
+                    XhtmlMatchers.hasXPath("/metadata/versioning/lastUpdated")
+                )
+            )
+        );
+        MatcherAssert.assertThat(
+            "Artifacts were not moved to the correct location",
+            this.storage.list(new Key.From(AstoMavenWithMoveTest.ASTO, latest)).join().size(),
+            new IsEqual<>(3)
+        );
+        MatcherAssert.assertThat(
+            "Upload directory was not cleaned up",
+            this.storage.list(new Key.From(AstoMavenWithMoveTest.ASTO_UPLOAD, latest))
+                .join().size(),
+            new IsEqual<>(0)
+        );
+    }
+
+    @Test
+    void generatesMetadataForFirstArtifact() {
+        final String version = "1.0";
+        new TestResource("maven-metadata.xml.example").saveTo(
+            this.storage,
+            new Key.From(AstoMavenWithMoveTest.LGR_UPLOAD, version, "maven-metadata.xml")
+        );
+        new AstoMavenWithMove(this.storage).update(
+            new Key.From(AstoMavenWithMoveTest.LGR_UPLOAD, version), AstoMavenWithMoveTest.LGR
+        ).toCompletableFuture().join();
+        MatcherAssert.assertThat(
+            "Maven metadata xml is not correct",
+            new XMLDocument(
+                this.storage.value(new Key.From(AstoMavenWithMoveTest.LGR, "maven-metadata.xml"))
+                    .thenCompose(content -> new PublisherAs(content).string(StandardCharsets.UTF_8))
+                    .join()
+            ),
+            new AllOf<>(
+                new ListOf<Matcher<? super XML>>(
+                    XhtmlMatchers.hasXPath("/metadata/groupId[text() = 'com.test']"),
+                    XhtmlMatchers.hasXPath("/metadata/artifactId[text() = 'logger']"),
+                    XhtmlMatchers.hasXPath("/metadata/versioning/latest[text() = '1.0']"),
+                    XhtmlMatchers.hasXPath("/metadata/versioning/release[text() = '1.0']"),
+                    XhtmlMatchers.hasXPath("/metadata/versioning/versions/version[text() = '1.0']"),
+                    XhtmlMatchers.hasXPath("/metadata/versioning/versions[count(//version) = 1]"),
+                    XhtmlMatchers.hasXPath("/metadata/versioning/lastUpdated")
+                )
+            )
+        );
+        MatcherAssert.assertThat(
+            "Upload directory was not cleaned up",
+            this.storage.list(new Key.From(AstoMavenWithMoveTest.LGR_UPLOAD, version))
+                .join().size(),
+            new IsEqual<>(0)
+        );
+    }
+
+    @Test
+    void addsMetadataChecksums() {
+        final String version = "0.1";
+        new TestResource("maven-metadata.xml.example").saveTo(
+            this.storage,
+            new Key.From(AstoMavenWithMoveTest.LGR_UPLOAD, version, "maven-metadata.xml")
+        );
+        new AstoMavenWithMove(this.storage).update(
+            new Key.From(AstoMavenWithMoveTest.LGR_UPLOAD, version), AstoMavenWithMoveTest.LGR
+        ).toCompletableFuture().join();
+        MatcherAssert.assertThat(
+            this.storage.list(AstoMavenWithMoveTest.LGR).join().stream()
+                .map(key -> new KeyLastPart(key).get())
+                .filter(key -> key.contains("maven-metadata.xml"))
+                .toArray(String[]::new),
+            Matchers.arrayContainingInAnyOrder(
+                "maven-metadata.xml", "maven-metadata.xml.sha1", "maven-metadata.xml.sha256",
+                "maven-metadata.xml.sha512", "maven-metadata.xml.md5"
+            )
+        );
+    }
+
+    @Test
+    void generatesWithSnapshotMetadata() throws Exception {
+        final String snapshot = "1.0-SNAPSHOT";
+        final Predicate<String> cond = item -> !item.contains(snapshot);
+        this.addFilesToStorage(cond, AstoMavenWithMoveTest.ASTO);
+        this.addFilesToStorage(cond.negate(), AstoMavenWithMoveTest.ASTO);
+        this.metadataAndVersions(snapshot, "0.20.2");
+        new AstoMavenWithMove(this.storage).update(
+            new Key.From(AstoMavenWithMoveTest.ASTO_UPLOAD, snapshot), AstoMavenWithMoveTest.ASTO
+        ).toCompletableFuture().get();
+        MatcherAssert.assertThat(
+            new XMLDocument(
+                this.storage.value(new Key.From(AstoMavenWithMoveTest.ASTO, "maven-metadata.xml"))
+                    .thenCompose(content -> new PublisherAs(content).string(StandardCharsets.UTF_8))
+                    .join()
+            ),
+            new AllOf<>(
+                new ListOf<Matcher<? super XML>>(
+                    // @checkstyle LineLengthCheck (20 lines)
+                    XhtmlMatchers.hasXPath("/metadata/groupId[text() = 'com.artipie']"),
+                    XhtmlMatchers.hasXPath("/metadata/artifactId[text() = 'asto']"),
+                    XhtmlMatchers.hasXPath("/metadata/versioning/latest[text() = '1.0-SNAPSHOT']"),
+                    XhtmlMatchers.hasXPath("/metadata/versioning/release[text() = '0.20.2']"),
+                    XhtmlMatchers.hasXPath("/metadata/versioning/versions/version[text() = '0.15']"),
+                    XhtmlMatchers.hasXPath("/metadata/versioning/versions/version[text() = '0.11.1']"),
+                    XhtmlMatchers.hasXPath("/metadata/versioning/versions/version[text() = '0.20.1']"),
+                    XhtmlMatchers.hasXPath("/metadata/versioning/versions/version[text() = '0.20.2']"),
+                    XhtmlMatchers.hasXPath("/metadata/versioning/versions/version[text() = '0.18']"),
+                    XhtmlMatchers.hasXPath("/metadata/versioning/versions/version[text() = '1.0-SNAPSHOT']"),
+                    XhtmlMatchers.hasXPath("metadata/versioning/versions[count(//version) = 6]"),
+                    XhtmlMatchers.hasXPath("/metadata/versioning/lastUpdated")
+                )
+            )
+        );
+        MatcherAssert.assertThat(
+            "Artifacts were not moved to the correct location",
+            this.storage.list(new Key.From(AstoMavenWithMoveTest.ASTO, snapshot)).join().size(),
+            new IsEqual<>(12)
+        );
+        MatcherAssert.assertThat(
+            "Upload directory was not cleaned up",
+            this.storage.list(new Key.From(AstoMavenWithMoveTest.ASTO_UPLOAD, snapshot))
+                .join().size(),
+            new IsEqual<>(0)
+        );
+    }
+
+    private void addFilesToStorage(final Predicate<String> condition, final Key base) {
+        final Storage resources = new FileStorage(new TestResource("com/artipie/asto").asPath());
+        final BlockingStorage bsto = new BlockingStorage(resources);
+        bsto.list(Key.ROOT).stream()
+            .map(Key::string)
+            .filter(condition)
+            .forEach(
+                item -> new Unchecked<>(
+                    () -> {
+                        new BlockingStorage(this.storage).save(
+                            new Key.From(base, item),
+                            new Unchecked<>(() -> bsto.value(new Key.From(item))).value()
+                        );
+                        return true;
+                    }
+                ).value()
+        );
+    }
+
+    private void metadataAndVersions(final String latest, final String... versions) {
+        new MetadataXml("com.artipie", "asto").addXmlToStorage(
+            this.storage,
+            new Key.From(AstoMavenWithMoveTest.ASTO_UPLOAD, latest, "maven-metadata.xml"),
+            new MetadataXml.VersionTags(
+                "0.20.2", "0.20.2",
+                Stream.concat(
+                    Stream.of("0.11.1", "0.15", "0.18", "0.20.1", latest),
+                    Stream.of(versions)
+                ).collect(Collectors.toList())
+            )
+        );
+    }
+}

--- a/src/test/resources-binary/com/artipie/asto/0.20.2/asto-0.20.2.jar.lastUpdated
+++ b/src/test/resources-binary/com/artipie/asto/0.20.2/asto-0.20.2.jar.lastUpdated
@@ -1,5 +1,0 @@
-#NOTE: This is a Maven Resolver internal implementation file, its format can be changed without prior notice.
-#Wed May 20 16:06:45 MSK 2020
-https\://repo.maven.apache.org/maven2/.lastUpdated=1589980005795
-http\://central.artipie.com/maven/.lastUpdated=1589980005197
-http\://central.artipie.com/maven/.error=

--- a/src/test/resources-binary/com/artipie/asto/0.20.2/asto-0.20.2.pom.lastUpdated
+++ b/src/test/resources-binary/com/artipie/asto/0.20.2/asto-0.20.2.pom.lastUpdated
@@ -1,5 +1,0 @@
-#NOTE: This is a Maven Resolver internal implementation file, its format can be changed without prior notice.
-#Wed May 20 16:06:44 MSK 2020
-https\://repo.maven.apache.org/maven2/.lastUpdated=1589980004221
-http\://central.artipie.com/maven/.lastUpdated=1589980003586
-http\://central.artipie.com/maven/.error=


### PR DESCRIPTION
Part of #227 
Added new `Maven` implementation: this implementation locks repository package and moves all the files to the right location after update is done. Will use this class in `PutMetadataChecksumSlice`, `AstoMaven` will be removed leter.