### PR TITLE
Put metadata by separate sub-key (directory)

### DIFF
--- a/src/main/java/com/artipie/maven/asto/AstoValidUpload.java
+++ b/src/main/java/com/artipie/maven/asto/AstoValidUpload.java
@@ -50,6 +50,7 @@ import java.util.stream.Collectors;
  * - artifacts checksums are correct
  * Upload contains all the uploaded artifacts, snapshot metadata and package metadata, here is the
  * example of upload layout:
+ * <pre>
  * .upload/com/example/logger/0.1-SNAPSHOT
  * |  logger-0.1.jar
  * |  logger-0.1.jar.sha1
@@ -64,6 +65,7 @@ import java.util.stream.Collectors;
  *    |  maven-metadata.xml       # package metadata
  *    |  maven-metadata.xml.sha1
  *    |  maven-metadata.xml.md5
+ * </pre>
  * @since 0.5
  * @checkstyle MagicNumberCheck (500 lines)
  */

--- a/src/main/java/com/artipie/maven/http/MavenSlice.java
+++ b/src/main/java/com/artipie/maven/http/MavenSlice.java
@@ -78,6 +78,17 @@ public final class MavenSlice extends Slice.Wrap {
                 new RtRulePath(
                     new RtRule.All(
                         new ByMethodsRule(RqMethod.PUT),
+                        new RtRule.ByPath(".*SNAPSHOT.*")
+                    ),
+                    new BasicAuthSlice(
+                        new UploadSlice(storage),
+                        users,
+                        new Permission.ByName(perms, Action.Standard.WRITE)
+                    )
+                ),
+                new RtRulePath(
+                    new RtRule.All(
+                        new ByMethodsRule(RqMethod.PUT),
                         new RtRule.ByPath(PutMetadataSlice.PTN_META)
                     ),
                     new BasicAuthSlice(

--- a/src/main/java/com/artipie/maven/http/PutMetadataChecksumSlice.java
+++ b/src/main/java/com/artipie/maven/http/PutMetadataChecksumSlice.java
@@ -55,9 +55,9 @@ import org.reactivestreams.Publisher;
 
 /**
  * This slice accepts PUT requests with maven-metadata.xml checksums, picks up corresponding
- * maven-metadata.xml from the package upload temp location and saves the checksum. If at least
- * sha1 and md5 checksums are present in the package upload location, this slice initiate repository
- * update.
+ * maven-metadata.xml from the package upload temp location and saves the checksum. If upload
+ * is ready to be added in the repository (see {@link ValidUpload#ready(Key)}), this slice initiate
+ * repository update.
  * @since 0.8
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
@@ -114,8 +114,9 @@ public final class PutMetadataChecksumSlice implements Slice {
                 this.findAndSave(body, alg, pkg).thenCompose(
                     key -> {
                         final CompletionStage<Response> resp;
-                        if (key.isPresent() && key.get().parent().isPresent()) {
-                            final Key location = key.get().parent().get();
+                        if (key.isPresent() && key.get().parent().isPresent()
+                            && key.get().parent().get().parent().isPresent()) {
+                            final Key location = key.get().parent().get().parent().get();
                             // @checkstyle NestedIfDepthCheck (10 lines)
                             resp = this.valid.ready(location).thenCompose(
                                 ready -> {

--- a/src/main/java/com/artipie/maven/http/PutMetadataSlice.java
+++ b/src/main/java/com/artipie/maven/http/PutMetadataSlice.java
@@ -43,13 +43,19 @@ import java.util.regex.Pattern;
 import org.reactivestreams.Publisher;
 
 /**
- * This slice accepts PUT requests with maven-metadata.xml, reads `latest` version from the
- * file and saves it to the temp location adding version before the filename:
- * `.upload/${package_name}/${version}/maven-metadata.xml`.
+ * This slice accepts PUT requests with package (not snapshot) maven-metadata.xml,
+ * reads `latest` version from the file and saves it to the temp location adding version and `meta`
+ * before the filename:
+ * `.upload/${package_name}/${version}/meta/maven-metadata.xml`.
  * @since 0.8
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 public final class PutMetadataSlice implements Slice {
+
+    /**
+     * Metadata sub-key.
+     */
+    public static final String SUB_META = "meta";
 
     /**
      * Metadata pattern.
@@ -84,6 +90,7 @@ public final class PutMetadataSlice implements Slice {
                             UploadSlice.TEMP,
                             new KeyFromPath(matcher.group("pkg")).string(),
                             new DeployMetadata(xml).release(),
+                            PutMetadataSlice.SUB_META,
                             "maven-metadata.xml"
                         ),
                         new Content.From(xml.getBytes(StandardCharsets.US_ASCII))

--- a/src/test/java/com/artipie/maven/asto/AstoMavenTest.java
+++ b/src/test/java/com/artipie/maven/asto/AstoMavenTest.java
@@ -33,6 +33,7 @@ import com.artipie.asto.fs.FileStorage;
 import com.artipie.asto.memory.InMemoryStorage;
 import com.artipie.asto.test.TestResource;
 import com.artipie.maven.MetadataXml;
+import com.artipie.maven.http.PutMetadataSlice;
 import com.jcabi.matchers.XhtmlMatchers;
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
@@ -146,7 +147,9 @@ final class AstoMavenTest {
         final String version = "1.0";
         new TestResource("maven-metadata.xml.example").saveTo(
             this.storage,
-            new Key.From(AstoMavenTest.LGR_UPLOAD, version, "maven-metadata.xml")
+            new Key.From(
+                AstoMavenTest.LGR_UPLOAD, version, PutMetadataSlice.SUB_META, "maven-metadata.xml"
+            )
         );
         new AstoMaven(this.storage).update(
             new Key.From(AstoMavenTest.LGR_UPLOAD, version), AstoMavenTest.LGR
@@ -183,7 +186,9 @@ final class AstoMavenTest {
         final String version = "0.1";
         new TestResource("maven-metadata.xml.example").saveTo(
             this.storage,
-            new Key.From(AstoMavenTest.LGR_UPLOAD, version, "maven-metadata.xml")
+            new Key.From(
+                AstoMavenTest.LGR_UPLOAD, version, PutMetadataSlice.SUB_META, "maven-metadata.xml"
+            )
         );
         new AstoMaven(this.storage).update(
             new Key.From(AstoMavenTest.LGR_UPLOAD, version), AstoMavenTest.LGR
@@ -211,7 +216,10 @@ final class AstoMavenTest {
             new Key.From(AstoMavenTest.LGR, "2.0", "logger-2.0.jar"), Content.EMPTY
         ).join();
         new MetadataXml("com.test", "logger").addXmlToStorage(
-            this.storage, new Key.From(AstoMavenTest.LGR_UPLOAD, "1.0/maven-metadata.xml"),
+            this.storage,
+            new Key.From(
+                AstoMavenTest.LGR_UPLOAD, version, PutMetadataSlice.SUB_META, "maven-metadata.xml"
+            ),
             new MetadataXml.VersionTags("2.0", "1.0", new ListOf<>("2.0", "1.0"))
         );
         new AstoMaven(this.storage).update(
@@ -314,7 +322,9 @@ final class AstoMavenTest {
     private void metadataAndVersions(final String latest, final String... versions) {
         new MetadataXml("com.artipie", "asto").addXmlToStorage(
             this.storage,
-            new Key.From(AstoMavenTest.ASTO_UPLOAD, latest, "maven-metadata.xml"),
+            new Key.From(
+                AstoMavenTest.ASTO_UPLOAD, latest, PutMetadataSlice.SUB_META, "maven-metadata.xml"
+            ),
             new MetadataXml.VersionTags(
                 "0.20.2", "0.20.2",
                 Stream.concat(

--- a/src/test/java/com/artipie/maven/asto/AstoValidUploadTest.java
+++ b/src/test/java/com/artipie/maven/asto/AstoValidUploadTest.java
@@ -29,6 +29,7 @@ import com.artipie.asto.blocking.BlockingStorage;
 import com.artipie.asto.memory.InMemoryStorage;
 import com.artipie.asto.test.TestResource;
 import com.artipie.maven.MetadataXml;
+import com.artipie.maven.http.PutMetadataSlice;
 import java.util.Arrays;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
@@ -125,7 +126,7 @@ public final class AstoValidUploadTest {
         final byte[] bytes = "artifact".getBytes();
         this.bsto.save(jar, bytes);
         new MetadataXml("com.test", "jogger").addXmlToStorage(
-            this.storage, new Key.From(upload, "maven-metadata.xml"),
+            this.storage, new Key.From(upload, PutMetadataSlice.SUB_META, "maven-metadata.xml"),
             new MetadataXml.VersionTags("1.0", "1.0", "1.0")
         );
         this.addMetadata(artifact);
@@ -155,7 +156,9 @@ public final class AstoValidUploadTest {
         );
         Arrays.stream(meta.split(";")).forEach(
             item -> this.bsto.save(
-                new Key.From(location, String.format("maven-metadata.%s", item)), new byte[]{}
+                new Key.From(
+                    location, PutMetadataSlice.SUB_META, String.format("maven-metadata.%s", item)
+                ), new byte[]{}
             )
         );
         MatcherAssert.assertThat(
@@ -165,8 +168,9 @@ public final class AstoValidUploadTest {
     }
 
     private void addMetadata(final Key base) {
-        new TestResource("maven-metadata.xml.example")
-            .saveTo(this.storage, new Key.From(base, "maven-metadata.xml"));
+        new TestResource("maven-metadata.xml.example").saveTo(
+            this.storage, new Key.From(base, PutMetadataSlice.SUB_META, "maven-metadata.xml")
+        );
     }
 
 }

--- a/src/test/java/com/artipie/maven/http/PutMetadataChecksumSliceTest.java
+++ b/src/test/java/com/artipie/maven/http/PutMetadataChecksumSliceTest.java
@@ -73,11 +73,11 @@ class PutMetadataChecksumSliceTest {
             new MetadataXml.VersionTags("0.1")
         ).getBytes(StandardCharsets.UTF_8);
         this.asto.save(
-            new Key.From(UploadSlice.TEMP, "com/example/abc/0.1/maven-metadata.xml"),
+            new Key.From(UploadSlice.TEMP, "com/example/abc/0.1/meta/maven-metadata.xml"),
             new Content.From(xml)
         ).join();
         this.asto.save(
-            new Key.From(UploadSlice.TEMP, "com/example/abc/0.2/maven-metadata.xml"),
+            new Key.From(UploadSlice.TEMP, "com/example/abc/0.2/meta/maven-metadata.xml"),
             new Content.From("any".getBytes())
         ).join();
         final byte[] mdfive = new ContentDigest(
@@ -100,7 +100,7 @@ class PutMetadataChecksumSliceTest {
             "Incorrect content was saved to storage",
             this.asto.value(
                 new Key.From(
-                    String.format(".upload/com/example/abc/0.1/maven-metadata.xml.%s", alg)
+                    String.format(".upload/com/example/abc/0.1/meta/maven-metadata.xml.%s", alg)
                 )
             ).join(),
             new ContentIs(mdfive)
@@ -118,11 +118,11 @@ class PutMetadataChecksumSliceTest {
             new MetadataXml.VersionTags("0.1")
         ).getBytes(StandardCharsets.UTF_8);
         this.asto.save(
-            new Key.From(UploadSlice.TEMP, "com/example/abc/0.1/maven-metadata.xml"),
+            new Key.From(UploadSlice.TEMP, "com/example/abc/0.1/meta/maven-metadata.xml"),
             new Content.From(xml)
         ).join();
         this.asto.save(
-            new Key.From(UploadSlice.TEMP, "com/example/abc/0.2/maven-metadata.xml"),
+            new Key.From(UploadSlice.TEMP, "com/example/abc/0.2/meta/maven-metadata.xml"),
             new Content.From("any".getBytes())
         ).join();
         final String alg = "md5";
@@ -155,11 +155,11 @@ class PutMetadataChecksumSliceTest {
             new MetadataXml.VersionTags("0.1")
         ).getBytes(StandardCharsets.UTF_8);
         this.asto.save(
-            new Key.From(UploadSlice.TEMP, "com/example/abc/0.1/maven-metadata.xml"),
+            new Key.From(UploadSlice.TEMP, "com/example/abc/0.1/meta/maven-metadata.xml"),
             new Content.From(xml)
         ).join();
         this.asto.save(
-            new Key.From(UploadSlice.TEMP, "com/example/abc/0.2/maven-metadata.xml"),
+            new Key.From(UploadSlice.TEMP, "com/example/abc/0.2/meta/maven-metadata.xml"),
             new Content.From("any".getBytes())
         ).join();
         final String alg = "sha1";
@@ -183,7 +183,7 @@ class PutMetadataChecksumSliceTest {
             "Incorrect content was saved to storage",
             this.asto.value(
                 new Key.From(
-                    String.format(".upload/com/example/abc/0.1/maven-metadata.xml.%s", alg)
+                    String.format(".upload/com/example/abc/0.1/meta/maven-metadata.xml.%s", alg)
                 )
             ).join(),
             new ContentIs(mdfive)
@@ -198,7 +198,7 @@ class PutMetadataChecksumSliceTest {
     @Test
     void returnsBadRequestIfSuitableMetadataFileNotFound() {
         this.asto.save(
-            new Key.From(UploadSlice.TEMP, "com/example/xyz/0.1/maven-metadata.xml"),
+            new Key.From(UploadSlice.TEMP, "com/example/xyz/0.1/meta/maven-metadata.xml"),
             new Content.From("xml".getBytes())
         ).join();
         final Maven.Fake mvn = new Maven.Fake();

--- a/src/test/java/com/artipie/maven/http/PutMetadataSliceTest.java
+++ b/src/test/java/com/artipie/maven/http/PutMetadataSliceTest.java
@@ -84,7 +84,9 @@ class PutMetadataSliceTest {
         );
         MatcherAssert.assertThat(
             "Metadata file was not saved to storage",
-            this.asto.value(new Key.From(".upload/com/example/any/0.2/maven-metadata.xml")).join(),
+            this.asto.value(
+                new Key.From(".upload/com/example/any/0.2/meta/maven-metadata.xml")
+            ).join(),
             new ContentIs(xml)
         );
     }


### PR DESCRIPTION
Part of #227 
Snapshot versions have their own metadata files, which maven uploads after all artifacts and before package metadata by path
```
PUT /com/artipie/asto/1.0-SNAPSHOT/maven-metadata.xml
```
This path coincides with the path we store package upload metadata, to avoid the problem I've made adapter to store package metadata into separate subdir (or sub-key) `meta`.
Snapshot metadata should not be processed, simply copied to local repository. 