### PR TITLE
Choose upload version when package metadata are uploaded

### DIFF
--- a/src/main/java/com/artipie/maven/asto/AstoMaven.java
+++ b/src/main/java/com/artipie/maven/asto/AstoMaven.java
@@ -27,10 +27,10 @@ import com.artipie.asto.Copy;
 import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
 import com.artipie.asto.SubStorage;
+import com.artipie.asto.ext.KeyLastPart;
 import com.artipie.asto.ext.PublisherAs;
 import com.artipie.maven.Maven;
 import com.artipie.maven.http.PutMetadataSlice;
-import com.artipie.maven.metadata.DeployMetadata;
 import com.artipie.maven.metadata.MavenMetadata;
 import com.jcabi.xml.XMLDocument;
 import java.util.Collection;
@@ -85,7 +85,7 @@ public final class AstoMaven implements Maven {
                     ).thenCompose(pub -> new PublisherAs(pub).asciiString())
                         .thenCompose(
                             str -> {
-                                versions.add(new DeployMetadata(str).release());
+                                versions.add(new KeyLastPart(upload).get());
                                 return new MavenMetadata(
                                     Directives.copyOf(new XMLDocument(str).node())
                                 ).versions(versions).save(
@@ -125,8 +125,11 @@ public final class AstoMaven implements Maven {
                 list -> new Copy(
                     subversion,
                     list.stream()
-                        .filter(key -> !key.string().contains(AstoMaven.MAVEN_META))
-                        .collect(Collectors.toList())
+                        .filter(
+                            key -> !key.string().contains(
+                                String.format("/%s/", PutMetadataSlice.SUB_META)
+                            )
+                        ).collect(Collectors.toList())
                 ).copy(new SubStorage(artifact, target))
             )
         );

--- a/src/main/java/com/artipie/maven/asto/AstoValidUpload.java
+++ b/src/main/java/com/artipie/maven/asto/AstoValidUpload.java
@@ -83,7 +83,7 @@ public final class AstoValidUpload implements ValidUpload {
      * Maven metadata and metadata checksums.
      */
     private static final Pattern PTN_META =
-        Pattern.compile(".+/maven-metadata.xml.(?:md5|sha1|sha256|sha512)");
+        Pattern.compile(".+/meta/maven-metadata.xml.(?:md5|sha1|sha256|sha512)");
 
     /**
      * Storage.

--- a/src/main/java/com/artipie/maven/metadata/DeployMetadata.java
+++ b/src/main/java/com/artipie/maven/metadata/DeployMetadata.java
@@ -25,6 +25,7 @@ package com.artipie.maven.metadata;
 
 import com.jcabi.xml.XMLDocument;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Extracts information from the metadata maven client sends on deploy.
@@ -56,5 +57,14 @@ public final class DeployMetadata {
         } else {
             return release.get(0);
         }
+    }
+
+    /**
+     * Reads snapshot versions from metadata.xml.
+     * @return List of snapshot versions
+     */
+    public List<String> snapshots() {
+        return new XMLDocument(this.data).xpath("//version/text()").stream()
+            .filter(item -> item.contains("SNAPSHOT")).collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/artipie/maven/metadata/DeployMetadata.java
+++ b/src/main/java/com/artipie/maven/metadata/DeployMetadata.java
@@ -25,6 +25,7 @@ package com.artipie.maven.metadata;
 
 import com.jcabi.xml.XMLDocument;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -63,8 +64,8 @@ public final class DeployMetadata {
      * Reads snapshot versions from metadata.xml.
      * @return List of snapshot versions
      */
-    public List<String> snapshots() {
+    public Set<String> snapshots() {
         return new XMLDocument(this.data).xpath("//version/text()").stream()
-            .filter(item -> item.contains("SNAPSHOT")).collect(Collectors.toList());
+            .filter(item -> item.contains("SNAPSHOT")).collect(Collectors.toSet());
     }
 }

--- a/src/test/java/com/artipie/maven/MavenITCase.java
+++ b/src/test/java/com/artipie/maven/MavenITCase.java
@@ -54,7 +54,6 @@ import org.hamcrest.core.StringContains;
 import org.hamcrest.text.StringContainsInOrder;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
@@ -166,8 +165,7 @@ public final class MavenITCase {
     }
 
     @ParameterizedTest
-    @ValueSource(booleans = {true})
-    @Disabled
+    @ValueSource(booleans = {true, false})
     void deploysSnapshot(final boolean anonymous) throws Exception {
         this.init(this.auth(anonymous));
         this.settings(this.getUser(anonymous));
@@ -341,12 +339,10 @@ public final class MavenITCase {
             String.format("Artifacts with %s version were not added to storage", version),
             this.storage.list(new Key.From("com/artipie/helloworld", version))
                 .join().stream().map(Key::string).collect(Collectors.toList()),
-            Matchers.hasItems(
-                new ListOf<Matcher<? extends String>>(
-                    new StringContains(".pom"),
-                    new StringContains(".jar"),
-                    new StringContains("maven-metadata.xml")
-                )
+            Matchers.allOf(
+                Matchers.hasItem(new StringContains(".jar")),
+                Matchers.hasItem(new StringContains(".pom")),
+                Matchers.hasItem(new StringContains("maven-metadata.xml"))
             )
         );
     }

--- a/src/test/java/com/artipie/maven/asto/AstoMavenTest.java
+++ b/src/test/java/com/artipie/maven/asto/AstoMavenTest.java
@@ -38,6 +38,7 @@ import com.jcabi.matchers.XhtmlMatchers;
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
 import java.nio.charset.StandardCharsets;
+import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -258,7 +259,7 @@ final class AstoMavenTest {
         final String snapshot = "1.0-SNAPSHOT";
         final Predicate<String> cond = item -> !item.contains(snapshot);
         this.addFilesToStorage(cond, AstoMavenTest.ASTO);
-        this.addFilesToStorage(cond.negate(), AstoMavenTest.ASTO);
+        this.addFilesToStorage(cond.negate(), AstoMavenTest.ASTO_UPLOAD);
         this.metadataAndVersions(snapshot, "0.20.2");
         new AstoMaven(this.storage).update(
             new Key.From(AstoMavenTest.ASTO_UPLOAD, snapshot), AstoMavenTest.ASTO
@@ -319,16 +320,16 @@ final class AstoMavenTest {
         );
     }
 
-    private void metadataAndVersions(final String latest, final String... versions) {
+    private void metadataAndVersions(final String release, final String... versions) {
         new MetadataXml("com.artipie", "asto").addXmlToStorage(
             this.storage,
             new Key.From(
-                AstoMavenTest.ASTO_UPLOAD, latest, PutMetadataSlice.SUB_META, "maven-metadata.xml"
+                AstoMavenTest.ASTO_UPLOAD, release, PutMetadataSlice.SUB_META, "maven-metadata.xml"
             ),
             new MetadataXml.VersionTags(
-                "0.20.2", "0.20.2",
+                Optional.empty(), Optional.of("0.20.2"),
                 Stream.concat(
-                    Stream.of("0.11.1", "0.15", "0.18", "0.20.1", latest),
+                    Stream.of("0.11.1", "0.15", "0.18", "0.20.1", release),
                     Stream.of(versions)
                 ).collect(Collectors.toList())
             )

--- a/src/test/java/com/artipie/maven/metadata/DeployMetadataTest.java
+++ b/src/test/java/com/artipie/maven/metadata/DeployMetadataTest.java
@@ -26,6 +26,7 @@ package com.artipie.maven.metadata;
 import com.artipie.maven.MetadataXml;
 import org.cactoos.list.ListOf;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -61,6 +62,21 @@ class DeployMetadataTest {
                     new MetadataXml.VersionTags("0.3", "12", "0.1")
                 )
             ).release()
+        );
+    }
+
+    @Test
+    void readsSnapshotVersions() {
+        final String one = "0.1-SNAPSHOT";
+        final String two = "0.2-SNAPSHOT";
+        final String three = "3.1-SNAPSHOT";
+        MatcherAssert.assertThat(
+            new DeployMetadata(
+                new MetadataXml("com.example", "logger").get(
+                    new MetadataXml.VersionTags(one, "0.7", "13", two, "0.145", three)
+                )
+            ).snapshots(),
+            Matchers.containsInAnyOrder(one, three, two)
         );
     }
 


### PR DESCRIPTION
Part of #227 
Implemented choosing upload version on maven metadata upload: we first try to find suitable uploading snapshot, if there is not any, save metadata by release version. Also fixed several other problems:
- moving files to the repository after the update in `AstoMaven` and its test (because of the mistake in the test bug in `AstoMaven`) was not visible
- `AstoValidUpload` should check package metadata from the `meta` sub-key
- extended `DeployMetadata` with method to read snapshot versions
- enabled `deploysSnapshot` in `MavenITCase`