### PR TITLE
Snapshots only artifacts

### DIFF
--- a/src/main/java/com/artipie/maven/http/PutMetadataSlice.java
+++ b/src/main/java/com/artipie/maven/http/PutMetadataSlice.java
@@ -98,19 +98,21 @@ public final class PutMetadataSlice implements Slice {
                             .stream().filter(
                                 item -> list.stream().anyMatch(key -> key.string().contains(item))
                             ).findFirst();
+                        final Key key;
+                        if (snapshot.isPresent()) {
+                            key = new Key.From(
+                                UploadSlice.TEMP, pkg.string(), snapshot.get(),
+                                PutMetadataSlice.SUB_META, PutMetadataSlice.MAVEN_METADATA
+                            );
+                        } else {
+                            key = new Key.From(
+                                UploadSlice.TEMP, pkg.string(),
+                                new DeployMetadata(xml).release(), PutMetadataSlice.SUB_META,
+                                PutMetadataSlice.MAVEN_METADATA
+                            );
+                        }
                         return this.asto.save(
-                            snapshot.map(
-                                item -> new Key.From(
-                                    UploadSlice.TEMP, pkg.string(), item,
-                                    PutMetadataSlice.SUB_META, PutMetadataSlice.MAVEN_METADATA
-                                )
-                            ).orElse(
-                                new Key.From(
-                                    UploadSlice.TEMP, pkg.string(),
-                                    new DeployMetadata(xml).release(), PutMetadataSlice.SUB_META,
-                                    PutMetadataSlice.MAVEN_METADATA
-                                )
-                            ),
+                            key,
                             new Content.From(xml.getBytes(StandardCharsets.US_ASCII))
                         );
                     }

--- a/src/test/java/com/artipie/maven/MavenITCase.java
+++ b/src/test/java/com/artipie/maven/MavenITCase.java
@@ -112,8 +112,7 @@ public final class MavenITCase {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     void downloadsDependency(final boolean anonymous) throws Exception {
-        this.init(this.auth(anonymous));
-        this.settings(this.getUser(anonymous));
+        this.init(anonymous);
         this.addHellowordToArtipie();
         MatcherAssert.assertThat(
             this.exec(
@@ -133,8 +132,7 @@ public final class MavenITCase {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     void deploysArtifact(final boolean anonymous) throws Exception {
-        this.init(this.auth(anonymous));
-        this.settings(this.getUser(anonymous));
+        this.init(anonymous);
         this.copyHellowordSourceToContainer();
         MatcherAssert.assertThat(
             "Failed to deploy version 1.0",
@@ -167,8 +165,7 @@ public final class MavenITCase {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     void deploysSnapshotAfterRelease(final boolean anonymous) throws Exception {
-        this.init(this.auth(anonymous));
-        this.settings(this.getUser(anonymous));
+        this.init(anonymous);
         this.copyHellowordSourceToContainer();
         MatcherAssert.assertThat(
             "Failed to deploy version 1.0",
@@ -215,8 +212,7 @@ public final class MavenITCase {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     void deploysSnapshot(final boolean anonymous) throws Exception {
-        this.init(this.auth(anonymous));
-        this.settings(this.getUser(anonymous));
+        this.init(anonymous);
         this.copyHellowordSourceToContainer();
         MatcherAssert.assertThat(
             "Failed to set version 1.0-SNAPSHOT",
@@ -261,7 +257,8 @@ public final class MavenITCase {
         MavenITCase.VERTX.close();
     }
 
-    void init(final Pair<Permissions, Authentication> auth) {
+    void init(final boolean anonymous) throws IOException {
+        final Pair<Permissions, Authentication> auth = this.auth(anonymous);
         this.storage = new InMemoryStorage();
         this.server = new VertxSliceServer(
             MavenITCase.VERTX,
@@ -274,6 +271,7 @@ public final class MavenITCase {
             .withWorkingDirectory("/home/")
             .withFileSystemBind(this.tmp.toString(), "/home");
         this.cntn.start();
+        this.settings(this.getUser(anonymous));
     }
 
     private String exec(final String... actions) throws Exception {


### PR DESCRIPTION
Closes #242 
Fixed `PutMetadataSlice` to handle snapshots only artifacts properly: when package has only snapshot versions there is no `release` tag in maven metadata and we should not try to obtain it.